### PR TITLE
Allow to load quests from outside the sandbox

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -507,6 +507,8 @@ class ClubhouseApplication(Gtk.Application):
 
         # @todo: Use a location from config
         libquest.Registry.load(os.path.dirname(__file__) + '/quests')
+        libquest.Registry.load(os.path.join(GLib.get_user_data_dir(), 'quests'))
+
         quest_sets = libquest.Registry.get_quest_sets()
 
         for quest_set in quest_sets:


### PR DESCRIPTION
We need a way to load the quests into the Clubhouse that's more agile
than having to go through the official integration process. That is,
instead of having to add the quests to the repo, waiting for them to be
reviewed, built, and updating the app, quest files could instead just be
dropped into a location that's taken into account by the Clubhouse and
is outside of the sandbox (for easy access).

This patch adds that capability by loading quests in a "quests" folder
from inside the app's data dir (i.e.
~/.var/app/com.endlessm.Clubhouse/data/quests/).

https://phabricator.endlessm.com/T24139