### PR TITLE
tools: Allow create a commit when updating the quests strings

### DIFF
--- a/tools/get-strings-file.sh
+++ b/tools/get-strings-file.sh
@@ -16,7 +16,16 @@ url="https://docs.google.com/spreadsheets/d/$KEY/gviz/tq?tqx=out:csv&sheet=$SHEE
 
 pushd "$source_dir"
 
-ret=$(wget "$url" -O "$source_dir/data/quests_strings.csv") || ret=$?
+ret=0
+wget "$url" -O "$source_dir/data/quests_strings.csv" || ret=$?
+
+if [ "$ret" == 0  ] && [ "$1" == '--commit' ]; then
+    # Ensure we don't include previously added things in this commit
+    git reset HEAD > /dev/null
+    # Add any changes to the CSV file and commit them
+    git add "$source_dir/data/quests_strings.csv"
+    git ci --no-verify -m 'data: Update quests strings CSV'
+fi
 
 popd
 


### PR DESCRIPTION
The get-strings-file.sh script now allows a "--commit" option which will
create git commit with the updated quests strings CSV file.
The motivation is that we accelerate the strings update process while at
the same time creating consistent commit messages for it.