### PR TITLE
clubhouse: Don't close the popup message when showing the page

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -254,7 +254,6 @@ class ClubhousePage(Gtk.EventBox):
         self._reset_quest_actions()
 
         self.add_tick_callback(AnimationSystem.step)
-        self._app_window.connect('show', lambda _window: self._shell_close_popup_message())
 
     def _setup_ui(self):
         builder = Gtk.Builder()


### PR DESCRIPTION
The quest dialog keep being shown even when the Clubhouse window is
shown.

https://phabricator.endlessm.com/T24331