### PR TITLE
clubhouse: configure window as skip_taskbar

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -618,6 +618,7 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
             super().__init__(application=app, title='Clubhouse',
                              type_hint=Gdk.WindowTypeHint.NORMAL,
                              role='eos-side-component',
+                             skip_taskbar_hint=True,
                              decorated=False)
 
             self.connect('realize', self._window_realize_cb)


### PR DESCRIPTION
We don't want the clubhouse to show up in alt-tab and the overview.

https://phabricator.endlessm.com/T24533