### PR TITLE
libquest: Run the quest loop at a higher frequency

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -125,14 +125,15 @@ class Quest(GObject.GObject):
         approach needed.
         '''
 
+        sleep_time = .1  # sec
         time_in_step = 0
         step_func = self.step_first
 
         while not self.is_cancelled():
             new_func = step_func(time_in_step)
             if new_func is None:
-                time.sleep(1)
-                time_in_step += 1
+                time.sleep(sleep_time)
+                time_in_step += sleep_time
             else:
                 step_func = new_func
                 time_in_step = 0


### PR DESCRIPTION
Sometimes, when clicking a button in the Shell quest view, the feedback
is not immediate. This is mainly because quests process their steps
every one second only, but this can be agravated if the steps take some
more time on their own.

Ideally we should call the next loop step when receiving the response
from the Shell, but for now let's just decrease the time slept between
each loop iteration.

https://phabricator.endlessm.com/T24592