### PR TITLE
clubhouse: Hide window if a character with a running quest is clicked

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -325,6 +325,14 @@ class ClubhousePage(Gtk.EventBox):
 
         self._message.reset()
 
+        # If a quest from this quest_set is already running, then just hide the window so the
+        # user focuses on the Shell's quest dialog
+        if self._quest_task:
+            quest = self._quest_task.get_source_object()
+            if quest in quest_set.get_quests():
+                self._app_window.hide()
+                return
+
         character = new_quest.get_main_character() if new_quest else quest_set.get_character()
         self._message.set_character(character)
 


### PR DESCRIPTION
A new UX spec indicates that if a quest is running, clicking on its
character in the Clubhouse will hide the Clubhouse's window instead of
proposing to launch the quest again.

https://phabricator.endlessm.com/T24546