### PR TITLE
lint: Ignore W504 line break after binary operator

### DIFF
--- a/flake8.cfg
+++ b/flake8.cfg
@@ -11,3 +11,4 @@ max-line-length = 100
 ignore =
     # imports at the top of the file (we need to call gi.require_version before other imports)
     E402
+    W504


### PR DESCRIPTION
In new versions of flake8 this rule comes by default, but our code
doesn't follow it.