### PR TITLE
clubhouse: Close the message if the window is closed by a quest set

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -337,6 +337,8 @@ class ClubhousePage(Gtk.EventBox):
             quest = self._quest_task.get_source_object()
             if quest in quest_set.get_quests():
                 self._app_window.hide()
+                # Hide the message here because it may be showing from another quest set
+                self._overlay_msg_box.hide()
                 return
 
         character = new_quest.get_main_character() if new_quest else quest_set.get_character()


### PR DESCRIPTION
When a quest is running, clicking on the same character that offered the
quest will just hide the Clubhouse window. However, if before we click
that character we had clicked in another (meaning a message is being
shown in the Clubhouse), then upon reopening the window, that message
would show as empty.

This patch hides the message when the window is closed in the mentioned
use-case.

https://phabricator.endlessm.com/T24696