### PR TITLE
clubhouse: Check for errors when playing the ambient sound

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -811,6 +811,11 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
             self.stop_ambient_sound()
 
     def _ambient_sound_uuid_cb(self, _proxy, uuid, _data):
+        if isinstance(uuid, GLib.Error):
+            logger.warning('Error when attempting to play sound: %s', uuid.message)
+            self._ambient_sound_uuid = None
+            return
+
         self._ambient_sound_uuid = uuid
 
     def stop_ambient_sound(self):


### PR DESCRIPTION
If the sounds doesn't exist in the service, then we get an error, and
thus we should check for that case.

https://phabricator.endlessm.com/T24716