### PR TITLE
clubhouse: fix window focus glitch

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -997,7 +997,7 @@ class ClubhouseApplication(Gtk.Application):
         page_name = arg_variant.unpack()
         if self._window:
             self._window.set_page(page_name)
-            self._window.show()
+            self._show_and_focus_window()
 
     def _vibility_notify_cb(self, window, pspec):
         if self._window.is_visible():


### PR DESCRIPTION
When the show() DBus method is called on the clubhouse, we use
gtk_window_present_with_time() to forward the timestamp passed through
by the shell; our goal is to ensure gdk_x11_window_set_user_time() is
called as a consequence of that, as that will correctly focus the
window as it's raised to top and made visible.

However, gtk_window_present_with_time() does not seem to honor the
timestamp in case the window was previously visible and then made
hidden [1]. (I guess hiding and showing a toplevel is not exactly a common
use case.)

This commit ensures the window is made visible before calling
gtk_window_present_with_time() to ensure GTK calls
gdk_x11_window_set_user_time() to honor our request.

[1] https://github.com/endlessm/gtk/blob/master/gtk/gtkwindow.c#L10454

https://phabricator.endlessm.com/T24771