### PR TITLE
corruption: Don't abort until app has quit for >1 s

### DIFF
--- a/eosclubhouse/quests/hackdexcorruption.py
+++ b/eosclubhouse/quests/hackdexcorruption.py
@@ -69,7 +69,7 @@ class HackdexCorruption(Quest):
             return self.step_delay2
 
         if not Desktop.app_is_running(self.TARGET_APP_DBUS_NAME):
-            return self.step_abort
+            return self.step_check_abort
 
     def step_delay2(self, time_in_step):
         if time_in_step > 2:
@@ -93,6 +93,12 @@ class HackdexCorruption(Quest):
 
         if self.confirmed_step():
             self.stop()
+
+    def step_check_abort(self, time_in_step):
+        if Desktop.app_is_running(self.TARGET_APP_DBUS_NAME):
+            return self.step_check_goal
+        if time_in_step > 2:
+            return self.step_abort
 
     # STEP Abort
     def step_abort(self, time_in_step):


### PR DESCRIPTION
This is a shot in the dark at fixing the corruption quest bug. I believe
it happened once that the app_is_running check occurred at the exact
moment that the hackdex app was restarting, and therefore went to the
abort step. This adds a "check abort" step that checks again in the next
iteration whether the app is still not running. If the app is running
again, it goes back to the "check goal" step. If the app is still not
running after a few checks, it moves on to the "abort" step.

https://phabricator.endlessm.com/T24870