### PR TITLE
clubhouse: Adapt window width to background width

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -55,7 +55,7 @@ ClubhouseIface = ('<node>'
                   '</interface>'
                   '</node>')
 
-DEFAULT_WINDOW_WIDTH = 484
+DEFAULT_WINDOW_WIDTH = 480
 
 
 class Character(GObject.GObject):


### PR DESCRIPTION
Match the window width to the background. The backgrounds are
480x1042.

https://phabricator.endlessm.com/T24376