### PR TITLE
data: Ensure the Clubhouse doesn't show up in the desktop search

### DIFF
--- a/data/eos-clubhouse.desktop
+++ b/data/eos-clubhouse.desktop
@@ -6,3 +6,4 @@ Comment=Clubhouse application
 Exec=eos-clubhouse
 Terminal=false
 StartupNotify=true
+NoDisplay=true


### PR DESCRIPTION
This patch adds the "NoDisplay" entry to the desktop file in order for
the application not to show up in the desktop searches.

https://phabricator.endlessm.com/T25029