### PR TITLE
clubhouse: Quit app after a timeout if it's idle

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -972,8 +972,11 @@ class ClubhouseApplication(Gtk.Application):
     QUEST_MSG_NOTIFICATION_ID = 'quest-message'
     QUEST_ITEM_NOTIFICATION_ID = 'quest-item'
 
+    _INACTIVITY_TIMEOUT = 5 * 60 * 1000  # millisecs
+
     def __init__(self):
         super().__init__(application_id=CLUBHOUSE_NAME,
+                         inactivity_timeout=self._INACTIVITY_TIMEOUT,
                          resource_base_path='/com/endlessm/Clubhouse')
 
         self._window = None


### PR DESCRIPTION
The Clubhouse has always kept running in the background even if it's
window has been closed, but it should rather be closed after a timeout
(to save resources, etc.).

These changes quit the Clubhouse if it's idle (its window is closed and
there's no task running in the background) for 5 minutes.

https://phabricator.endlessm.com/T24714