### PR TITLE
system: Don't log when checking if an app is running

### DIFF
--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -92,8 +92,7 @@ class Desktop:
     def app_is_running(klass, name):
         try:
             klass.get_dbus_proxy().GetNameOwner('(s)', name)
-        except GLib.Error as e:
-            logger.error(e)
+        except GLib.Error:
             return False
         return True
 


### PR DESCRIPTION
The Desktop.app_is_running() function is used very often by the quests
and was logging every time a quest was not running. Since this method
is just a simple check, and not an attempt to use the app, we should not
log such a message as it clutters the output quite a lot.