### PR TITLE
clubhouse: Ensure the debug mode action uses a window if needed

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -1114,6 +1114,7 @@ class ClubhouseApplication(Gtk.Application):
 
     def _debug_mode_action_cb(self, action, arg_variant):
         self._debug_mode = arg_variant.unpack()
+        self._ensure_window()
 
     def _quest_user_answer(self, action, action_id):
         if self._window:


### PR DESCRIPTION
The debug mode action was only turning the debug mode on, but if the
Clubhouse was not already running, it would not proceed to show a
window.
This patch ensures that a window is created and shown if needed.

https://phabricator.endlessm.com/T25156