### PR TITLE
quests: Set the OSIntro quest as complete when it's done

### DIFF
--- a/eosclubhouse/quests/episode1/osintro.py
+++ b/eosclubhouse/quests/episode1/osintro.py
@@ -96,6 +96,7 @@ class OSIntro(Quest):
         self.wait_for_one([confirm_action, app_changes_action])
 
         if self.confirmed_step():
+            self.conf['complete'] = True
             self.available = False
             Sound.play('quests/quest-complete')
             return self.step_wrapup


### PR DESCRIPTION
An error in the recent port of OSIntro to the non-polling approach
didn't set the quest as complete, and thus, it'd never be considered
as such. This patch adds that back.

https://phabricator.endlessm.com/T25214