### PR TITLE
clubhouse: Play "quests/key-given" when giving item

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -583,6 +583,8 @@ class ClubhousePage(Gtk.EventBox):
         notification.add_button('OK', 'app.item-accept-answer')
         notification.add_button('Show me', "app.show-page('{}')".format('inventory'))
 
+        Sound.play('quests/key-given')
+
         self._app.send_quest_item_notification(notification)
 
     def show_message(self, txt, answer_choices=[]):


### PR DESCRIPTION
Instead of having the quests/key-given play during the character
dialogue when they are about to give you a key, play it when the "You
got an item!" notification opens.

https://phabricator.endlessm.com/T25291