### PR TITLE
quests: Fix returning the last step in the LostFiles quest

### DIFF
--- a/eosclubhouse/quests/episode1/lostfiles.py
+++ b/eosclubhouse/quests/episode1/lostfiles.py
@@ -41,7 +41,7 @@ class LostFiles(Quest):
             self.show_message('EXPLANATION4',
                               choices=[('End of Episode 1', self._confirm_step)])
         if self.confirmed_step():
-            self.step_finish_episode
+            return self.step_finish_episode
 
     def step_finish_episode(self, time_in_step):
         if time_in_step == 0:


### PR DESCRIPTION
The previous commit (b95e39f) mistakenly forgot to return the last step,
and as a result, the LostFiles quest would never be finished nor could
the episode be completed.

https://phabricator.endlessm.com/T25123