### PR TITLE
quests: Default 'new-icon' sound if app added to the desktop grid

### DIFF
--- a/eosclubhouse/quests/episode1/fizzicsintro.py
+++ b/eosclubhouse/quests/episode1/fizzicsintro.py
@@ -39,8 +39,9 @@ class FizzicsIntro(Quest):
 
         self.show_hints_message('LAUNCH')
 
-        Sound.play('quests/new-icon')
-        Desktop.add_app_to_grid(self.APP_NAME)
+        # If no delay were added, step-begin sound would overlap shadow
+        # the 'new icon' sound.
+        Desktop.add_app_to_grid(self.APP_NAME, delay=3)
         Desktop.focus_app(self.APP_NAME)
 
         self.wait_for_app_launch(self._app)

--- a/eosclubhouse/quests/episode1/osintro.py
+++ b/eosclubhouse/quests/episode1/osintro.py
@@ -18,7 +18,6 @@ class OSIntro(Quest):
         self.show_hints_message('LAUNCH')
 
         if not self._app.is_running():
-            Sound.play('quests/new-icon')
             Desktop.add_app_to_grid(self.APP_NAME)
             Desktop.focus_app(self.APP_NAME)
             self.wait_for_app_launch(self._app)

--- a/eosclubhouse/quests/episode1/roster.py
+++ b/eosclubhouse/quests/episode1/roster.py
@@ -33,7 +33,6 @@ class Roster(Quest):
 
     def step_launch(self):
         self.show_hints_message('LAUNCH')
-        Sound.play('quests/new-icon')
         Desktop.add_app_to_grid(self.APP_NAME)
         Desktop.focus_app(self.APP_NAME)
 

--- a/eosclubhouse/quests/episode2/lightspeedintro.py
+++ b/eosclubhouse/quests/episode2/lightspeedintro.py
@@ -22,7 +22,9 @@ class LightSpeedIntro(Quest):
 
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
-            Desktop.add_app_to_grid(self.APP_NAME)
+            # If no delay were added, step-begin sound would overlap shadow
+            # the 'new icon' sound.
+            Desktop.add_app_to_grid(self.APP_NAME, delay=3)
             Desktop.focus_app(self.APP_NAME)
 
             self.wait_for_app_launch(self._app)

--- a/eosclubhouse/quests/episode2/lightspeedtweak.py
+++ b/eosclubhouse/quests/episode2/lightspeedtweak.py
@@ -27,7 +27,9 @@ class LightSpeedTweak(Quest):
     def step_begin(self):
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
-            Desktop.add_app_to_grid(self.APP_NAME)
+            # If no delay were added, step-begin sound would overlap shadow
+            # the 'new icon' sound.
+            Desktop.add_app_to_grid(self.APP_NAME, delay=3)
             Desktop.focus_app(self.APP_NAME)
             self.wait_for_app_launch(self._app)
 


### PR DESCRIPTION
https://phabricator.endlessm.com/T25111

@ptomato 
> my reasoning was that if we are always playing the new-icon sound when a new icon appears, or always playing the quest-aborted sound when the quest is aborted, then we should do that unconditionally in the code, and not require the authors to put that sound in the spreadsheet.


I am adding some delays, because otherwise you will not be able to hear the new-icon sounds.