### PR TITLE
apps: Make LightSpeed.set_level use the level index from 1

### DIFF
--- a/eosclubhouse/apps.py
+++ b/eosclubhouse/apps.py
@@ -15,10 +15,8 @@ class LightSpeed(App):
 
         levelCount = self.get_js_property('availableLevels')
 
-        levelIndex = level - 1
-
         if levelCount < level:
             if not self.set_js_property('availableLevels', ('i', level)):
                 return False
 
-        return self.set_js_property('currentLevel', ('i', levelIndex))
+        return self.set_js_property('currentLevel', ('i', level))


### PR DESCRIPTION
This is in order to accommodate a recent change in the LightSpeed app
that makes levels now start from 1.

https://phabricator.endlessm.com/T25404