### PR TITLE
libquest: Fix multiple use of Quest.with_app_launched

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -956,25 +956,23 @@ class Quest(GObject.GObject):
         self.notify('available')
 
     def with_app_launched(app_name, otherwise):
-        app_was_quit = False
-        handler_id = 0
-
-        def _app_running_changed(app, instance, app_quit_callback):
-            nonlocal app_was_quit
-            if not app.is_running():
-                app.disconnect_running_change(handler_id)
-                app_was_quit = True
-                app_quit_callback(instance)
-
         def wrapper(func):
             app = App(app_name)
 
             def wrapped_func(instance, *args):
-                nonlocal app_was_quit
-                nonlocal handler_id
+                app_was_quit = False
+                handler_id = 0
 
                 if not app.is_running():
                     return otherwise(instance)
+
+                def _app_running_changed(app, instance, app_quit_callback):
+                    nonlocal app_was_quit
+
+                    if not app.is_running():
+                        app.disconnect_running_change(handler_id)
+                        app_was_quit = True
+                        app_quit_callback(instance)
 
                 # Check if the app is quit while the wrapped function is being run
                 # if so, we run the alternative callback instead


### PR DESCRIPTION
If the Quest.with_app_launched decorated is used, and its app is closed
then the second time the same decorated function is called (i.e. if the
quest is restarted), the decorator will always act as if the app had been
called. This happened due to a scope issue related to how the decorator's
local variables were being used; particularly the local variable that was
setting whether the app had been quit was declared in the decorator's
scope, not in the wrapper's scope, and thus was never reset the second
time that the decorator was used.

This patch moves the apps (and a helper function) declaration into the
wrapper, which fixes this issue.

https://phabricator.endlessm.com/T25214