### PR TITLE
libquest: Use new event loop when waiting on actions

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -312,12 +312,10 @@ class _QuestRunContext:
 
         self._debug_actions = set(action_list)
 
-        loop = asyncio.get_event_loop()
-
-        if not loop.is_closed():
-            loop.run_until_complete(wait_or_timeout(futures, timeout))
-            loop.stop()
-            loop.close()
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(wait_or_timeout(futures, timeout))
+        loop.stop()
+        loop.close()
 
         self._debug_actions.clear()
 


### PR DESCRIPTION
The logic for waiting for actions was using the currently event loop
and calling "run_until_complete" on them. This meant, that if the loop
had several tasks at a time, and one of them completed, the
run_until_complete would finish even if the task we were waiting for
was not the one that caused the run interruption.

This led to an issue when quitting an application while having a quest
step that depends on that application being launched: the quests'
abort step shows a message informing the user that it has stopped and
called on a pause of 5 seconds (to give a change for the user to read
it), however, if an action within the current step was waiting on any
app changes, it'd also be resolved at that point which would cause the
mentioned pause to be cancelled.

To avoid this, now the "wait_for_one" method uses a new event loop to
wait on the given actions, thus making sure that it does run until one
of them if finished (and not any others who may be at that point being
executed in the same/default event loop).

https://phabricator.endlessm.com/T25472