### PR TITLE
clubhouse: Reset actions before calling the callback

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -611,18 +611,19 @@ class ClubhousePage(Gtk.EventBox):
         return key
 
     def quest_action(self, action_key):
+        actions = self._actions
         action = self._actions.get(action_key)
+
+        self._reset_quest_actions()
 
         if action is None:
             logger.debug('Failed to get action for key %s', action_key)
-            logger.debug('Current actions: %s', self._actions)
+            logger.debug('Current actions: %s', actions)
             return
 
         # Call the action
         callback, args = action[1], action[2:]
         callback(*args)
-
-        self._reset_quest_actions()
 
     def set_quest_to_background(self):
         if self._current_quest:


### PR DESCRIPTION
The code that deals with the quests' user actions (clicking a button
in a notification's banner) was calling the callback for that action
and reseting the actions afterwards, however, if the mentioned
callback had set up some new actions, they would all be removed as
well by this reset.

This was not noticeable before the code that removes the support for
legacy quests' API (d036d293) because that code also emitted quests'
signals from the idle loop, so the actions' code was delayed a
little bit and thus any new actions would not be removed by the
logic mentioned above.

This patch fixes this issue by resetting the actions before calling
the callback, thus "saving" any newly set up actions from being
reset.

https://phabricator.endlessm.com/T25496