### PR TITLE
clubhouse: Init the hack account service

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -31,7 +31,7 @@ import time
 
 from gi.repository import Gdk, Gio, GLib, Gtk, GObject, Json
 from eosclubhouse import config, logger, libquest, utils
-from eosclubhouse.system import GameStateService, Sound
+from eosclubhouse.system import AccountService, GameStateService, Sound
 from eosclubhouse.utils import ClubhouseState, Performance, SimpleMarkupParser
 from eosclubhouse.animation import Animation, AnimationImage, AnimationSystem, Animator, \
     get_character_animation_dirs
@@ -1241,6 +1241,9 @@ class ClubhouseApplication(Gtk.Application):
             action = Gio.SimpleAction.new(name, variant_type)
             action.connect('activate', callback)
             self.add_action(action)
+
+        # Make sure that we create a user account if there's none
+        AccountService().init_accounts()
 
     def _ensure_registry_loaded(self):
         if not self._registry_loaded:

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -25,6 +25,7 @@ import time
 
 from eosclubhouse import logger
 from eosclubhouse.soundserver import HackSoundServer
+from eosclubhouse.utils import Performance
 from gi.repository import GLib, GObject, Gio, Json
 
 
@@ -389,6 +390,52 @@ class GameStateService(GObject.GObject):
     @staticmethod
     def _is_key_error(error):
         return Gio.DBusError.get_remote_error(error) == 'com.endlessm.GameStateService.KeyError'
+
+
+class AccountService(GObject.GObject):
+
+    _proxy = None
+
+    @classmethod
+    def _get_proxy_and_call(klass, method, callback, *params):
+        Gio.DBusProxy.new_for_bus(Gio.BusType.SESSION,
+                                  0,
+                                  None,
+                                  'com.endlessm.HackAccountService',
+                                  '/com/endlessm/HackAccountService',
+                                  'com.endlessm.HackAccountService',
+                                  None,
+                                  klass._get_proxy_finish,
+                                  method, callback, *params)
+
+    @classmethod
+    def _get_proxy_finish(klass, proxy, res, method, callback, *params):
+        try:
+            klass._proxy = proxy.new_for_bus_finish(res)
+        except GLib.Error as e:
+            logger.error('Cannot get proxy for HackAccountService: %s', e.message)
+            return
+
+        klass._call_async(method, callback, *params)
+
+    @classmethod
+    def _call_async(klass, method, callback, *params):
+        if not klass._proxy:
+            klass._get_proxy_and_call(method, callback, *params)
+            return
+
+        klass._proxy.call(method, None, Gio.DBusCallFlags.NONE, -1, None,
+                          callback, *params)
+
+    def _init_callback(self, proxy, res):
+        try:
+            proxy.call_finish(res)
+        except GLib.Error as e:
+            logger.error('Cannot start the HackAccountService: %s', e.message)
+
+    @Performance.timeit
+    def init_accounts(self):
+        self._call_async('InitAccounts', self._init_callback)
 
 
 # Allow to import the HackSoundServer from the system while using a more friendly name


### PR DESCRIPTION
The hack-account-service is a flatpak app, we can't auto launch this
service from the operating system part, so we can do the initial startup
from the clubhouse.

https://phabricator.endlessm.com/T25480