### PR TITLE
quests: handle game state in BreakingIn and Investigation

### DIFF
--- a/eosclubhouse/quests/episode2/breakingin.py
+++ b/eosclubhouse/quests/episode2/breakingin.py
@@ -5,6 +5,7 @@ from eosclubhouse.system import App, Sound
 class BreakingIn(Quest):
 
     APP_NAME = 'com.endlessm.OperatingSystemApp'
+    LEVEL2_LOCK = 'lock.OperatingSystemApp.2'
 
     def __init__(self):
         super().__init__('BreakingIn', 'riley')
@@ -36,35 +37,53 @@ class BreakingIn(Quest):
 
         return self.step_flipped
 
-    def level2_is_unlocked(self):
-        # @todo: Check if the needed panel is unlocked
-        return self.debug_skip()
+    def level2_lock_tried(self):
+        if self.debug_skip():
+            return True
+
+        lock = self.gss.get(self.LEVEL2_LOCK)
+        return lock is not None and lock.get('tried', False)
+
+    def set_trap_sequence(self, sequence):
+        lock = self.gss.get(self.LEVEL2_LOCK) or {}
+        lock.update({'trap_sequence': sequence})
+        self.gss.set(self.LEVEL2_LOCK, lock)
+
+    def end_trap_sequence(self):
+        lock = self.gss.get(self.LEVEL2_LOCK) or {}
+        lock.pop('trap_sequence', None)
+        lock.update({'locked': False})
+        self.gss.set(self.LEVEL2_LOCK, lock)
 
     @Quest.with_app_launched(APP_NAME)
     def step_flipped(self):
         self.show_hints_message('FLIPPED')
 
-        while not (self.level2_is_unlocked() or self.is_cancelled()):
-            self.wait_for_app_js_props_changed(self._app, ['DummyProperty'])
+        while not (self.level2_lock_tried() or self.is_cancelled()):
+            self.connect_gss_changes().wait()
 
         return self.step_unlocked
 
     @Quest.with_app_launched(APP_NAME)
     def step_unlocked(self):
+        self.set_trap_sequence(0)
         self.wait_confirm('UNLOCKED')
         return self.step_starttrap
 
     # Not aborting quest even if app exits
     def step_starttrap(self):
+        self.set_trap_sequence(1)
         self.wait_confirm('STARTTRAP')
         return self.step_trapped
 
     def step_trapped(self):
+        self.set_trap_sequence(2)
         self.wait_confirm('TRAPPED')
         return self.step_archivist
 
     def step_archivist(self):
         self.show_confirm_message('ARCHIVIST', confirm_label='End of Episode 2').wait()
+        self.end_trap_sequence()
         if not self.confirmed_step():
             return
 

--- a/eosclubhouse/quests/episode2/investigation.py
+++ b/eosclubhouse/quests/episode2/investigation.py
@@ -5,6 +5,7 @@ from eosclubhouse.system import App, Sound
 class Investigation(Quest):
 
     APP_NAME = 'com.endlessm.OperatingSystemApp'
+    LEVEL2_LOCK = 'lock.OperatingSystemApp.2'
 
     def __init__(self):
         super().__init__('Investigation', 'riley')
@@ -36,12 +37,19 @@ class Investigation(Quest):
         self.wait_for_app_js_props_changed(self._app, ['flipped'])
         return self.step_wait_for_flip
 
+    def level2_lock_tried(self):
+        if self.debug_skip():
+            return True
+
+        lock = self.gss.get(self.LEVEL2_LOCK)
+        return lock is not None and lock.get('tried', False)
+
     @Quest.with_app_launched(APP_NAME)
     def step_unlock(self):
         self.show_hints_message('UNLOCK')
 
-        while not (self.debug_skip() or self.is_cancelled()):
-            self.wait_for_app_js_props_changed(self._app, ['DummyProperty'])
+        while not (self.level2_lock_tried() or self.is_cancelled()):
+            self.connect_gss_changes().wait()
 
         return self.step_stop
 


### PR DESCRIPTION
These two quests communicate with the level 2 lock from the System app
toolbox. Both quests wait for the state "tried" of the lock, set when
the user tries to open the lock. Unlike other locks, this one doesn't
unlock automatically with the key.

The Investigation quest displays a message, preventing the player to
use the lock.

The BreakingIn quest plays a trapped sequence where Riley falls into a
trap. By setting "trap sequence" state for the lock.

https://phabricator.endlessm.com/T25503