### PR TITLE
quests: Restore the use of timeout based hints in FirstContact

### DIFF
--- a/eosclubhouse/quests/episode1/firstcontact.py
+++ b/eosclubhouse/quests/episode1/firstcontact.py
@@ -33,37 +33,52 @@ class FirstContact(Quest):
     def step_begin(self):
         self.wait_for_app_launch(self._app)
         self.pause(3)
-        return self.step_one
 
-    @Quest.with_app_launched(APP_NAME, otherwise='step_reward')
-    def step_one(self):
         if self._is_app_flipped():
-            return self.step_dohack
+            return self.step_wait_for_hack
 
-        self.show_hints_message('WELCOME')
-        while not self._is_app_flipped():
-            self.wait_for_app_js_props_changed(self._app, ['mode'])
-
-        return self.step_dohack
+        return self.step_wait_for_flip
 
     @Quest.with_app_launched(APP_NAME, otherwise='step_reward')
-    def step_dohack(self):
-        if self._is_app_hacked():
-            return self.step_flipback
+    def step_wait_for_flip(self):
+        for hint_msg_id in ['WELCOME', 'WELCOME_HINT1']:
+            if self._is_app_flipped() or self.is_cancelled():
+                break
+            self.wait_for_app_js_props_changed(self._app, ['mode'], timeout=10)
+            if not self._is_app_flipped():
+                self.show_message(hint_msg_id)
 
-        self.show_hints_message('GOAL')
-        while not self._is_app_hacked():
+        while not self._is_app_flipped() and not self.is_cancelled():
             self.wait_for_app_js_props_changed(self._app, ['mode'])
 
-        return self.step_flipback
+        return self.step_wait_for_hack
 
     @Quest.with_app_launched(APP_NAME, otherwise='step_reward')
-    def step_flipback(self):
-        if self._is_app_flipped_back():
-            return self.step_reward
+    def step_wait_for_hack(self):
+        self.show_message('GOAL')
 
-        self.show_hints_message('FLIPBACK')
-        while not self._is_app_flipped_back():
+        for hint_msg_id in ['GOAL_HINT1', 'GOAL_HINT2']:
+            if self._is_app_hacked() or self.is_cancelled():
+                break
+            self.wait_for_app_js_props_changed(self._app, ['mode'], timeout=20)
+            if not self._is_app_hacked():
+                self.show_message(hint_msg_id)
+
+        while not self._is_app_hacked() and not self.is_cancelled():
+            self.wait_for_app_js_props_changed(self._app, ['mode'])
+
+        return self.step_wait_for_flipback
+
+    @Quest.with_app_launched(APP_NAME, otherwise='step_reward')
+    def step_wait_for_flipback(self):
+        self.show_message('FLIPBACK')
+
+        if not self._is_app_flipped_back():
+            self.wait_for_app_js_props_changed(self._app, ['mode'], timeout=8)
+            if not self._is_app_flipped_back():
+                self.show_message('FLIPBACK_HINT1')
+
+        while not self._is_app_flipped_back() and not self.is_cancelled():
             self.wait_for_app_js_props_changed(self._app, ['mode'])
 
         return self.step_reward


### PR DESCRIPTION
The First Contact was designed to show hints on a timeout basis, rather
then showing the "Hints" button that every other quest does. With the
port to the non-polling approach, this was modified to use the Hints
button for consistency, but this approach hasn't been tested yet with
users, and thus this patch rolls it back to the original way.

https://phabricator.endlessm.com/T25601