### PR TITLE
libquest: Support callback parameters in show_message

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -489,7 +489,7 @@ class ClubhousePage(Gtk.EventBox):
     def _quest_message_cb(self, quest, message_txt, answer_choices, character_id, character_mood,
                           sfx_sound, bg_sound):
         logger.debug('Message: %s character_id=%s mood=%s choices=[%s]', message_txt, character_id,
-                     character_mood, '|'.join([answer for answer, _cb in answer_choices]))
+                     character_mood, '|'.join([answer for answer, _cb, *_args in answer_choices]))
 
         self._reset_quest_actions()
 

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -829,7 +829,7 @@ class Quest(GObject.GObject):
 
         possible_answers = []
         if options.get('choices'):
-            possible_answers = [(text, callback) for text, callback in options['choices']]
+            possible_answers = [(text, callback, *args) for text, callback, *args in options['choices']]
 
         if options.get('use_confirm'):
             confirm_label = options.get('confirm_label', '>')


### PR DESCRIPTION
Now that we're using the "choices" option for the show_message method,
it'd be nice to also pass it parameters for the callback.

This patch adds that by making further elements to the "choices"
tuples.

https://phabricator.endlessm.com/T25620