### PR TITLE
quests: Add page change detection to the Intro quest

### DIFF
--- a/eosclubhouse/quests/episode2/intro.py
+++ b/eosclubhouse/quests/episode2/intro.py
@@ -8,8 +8,15 @@ class Intro(Quest):
         super().__init__('Intro', 'riley')
 
     def step_begin(self):
-        self.show_confirm_message('EXPLANATION').wait()
-        # TODO: Wait for clicking on the Episodes tab on the Clubhouse
+        self.show_message('EXPLANATION')
+
+        while (self.clubhouse_state.current_page != self.clubhouse_state.Page.EPISODES and
+               not self.is_cancelled()):
+            self.connect_clubhouse_changes(['current-page']).wait()
+
+        return self.step_success
+
+    def step_success(self):
         self.show_confirm_message('EPISODESTAB', confirm_label='Bye').wait()
 
         self.conf['complete'] = True


### PR DESCRIPTION
The Intro quest of the Episose 2 expects the user to access the
episodes' page, so this patch adds that detection.

https://phabricator.endlessm.com/T25578