### PR TITLE
quests: Add game state for the visibility of Lightspeed topics

### DIFF
--- a/eosclubhouse/apps.py
+++ b/eosclubhouse/apps.py
@@ -1,4 +1,4 @@
-from eosclubhouse.system import App
+from eosclubhouse.system import App, GameStateService
 
 
 class LightSpeed(App):
@@ -7,6 +7,13 @@ class LightSpeed(App):
 
     def __init__(self):
         super().__init__(self.APP_NAME)
+        self._gss = None
+
+    @property
+    def gss(self):
+        if self._gss is None:
+            self._gss = GameStateService()
+        return self._gss
 
     def set_level(self, level):
         '''Sets the level to be played (starting from 1).'''
@@ -20,3 +27,9 @@ class LightSpeed(App):
                 return False
 
         return self.set_js_property('startLevel', ('i', level))
+
+    def reveal_topic(self, topic):
+        '''Sets a key in the game state so that the given topic ID is revealed
+        in Lightspeed's toolbox.'''
+
+        self.gss.set('lightspeed.topic.{}'.format(topic), {'visible': True})

--- a/eosclubhouse/quests/episode2/lightspeedenemya1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya1.py
@@ -46,6 +46,8 @@ class LightSpeedEnemyA1(Quest):
             self.show_hints_message('PLAY')
             return self.step_play
 
+        self._app.reveal_topic('spawnEnemy')
+
         self.show_hints_message('CHANGEENEMY')
 
         self.wait_for_app_js_props_changed(self._app, ['flipped'])

--- a/eosclubhouse/quests/episode2/lightspeedenemya2.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya2.py
@@ -12,6 +12,8 @@ class LightSpeedEnemyA2(Quest):
         self._app = LightSpeed()
 
     def step_begin(self):
+        self._app.reveal_topic('spawnEnemy')
+
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
             self.give_app_icon(self.APP_NAME)
@@ -32,6 +34,8 @@ class LightSpeedEnemyA2(Quest):
         if (not self._app.get_js_property('flipped') and self._app.get_js_property('playing')) \
            or self.debug_skip():
             return self.step_play
+
+        self._app.reveal_topic('updateSpinner')
 
         self.show_hints_message('CODE')
 

--- a/eosclubhouse/quests/episode2/lightspeedenemya3.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya3.py
@@ -16,6 +16,8 @@ class LightSpeedEnemyA3(Quest):
         self._app = LightSpeed()
 
     def step_begin(self):
+        self._app.reveal_topic('spawnEnemy')
+
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
             self.give_app_icon(self.APP_NAME)
@@ -36,6 +38,8 @@ class LightSpeedEnemyA3(Quest):
         if (not self._app.get_js_property('flipped') and self._app.get_js_property('playing')) \
            or self.debug_skip():
             return self.step_play
+
+        self._app.reveal_topic('updateSpinner')
 
         self.show_hints_message('CODE')
 

--- a/eosclubhouse/quests/episode2/lightspeedenemya4.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya4.py
@@ -17,6 +17,9 @@ class LightSpeedEnemyA4(Quest):
         self._app = LightSpeed()
 
     def step_begin(self):
+        self._app.reveal_topic('spawnEnemy')
+        self._app.reveal_topic('updateSpinner')
+
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
             self.give_app_icon(self.APP_NAME)

--- a/eosclubhouse/quests/episode2/lightspeedenemyb1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyb1.py
@@ -47,6 +47,11 @@ class LightSpeedEnemyB1(Quest):
            or self.debug_skip():
             return self.step_play
 
+        if code_msg_id == 'CODE1':
+            self._app.reveal_topic('spawnEnemy')
+        elif code_msg_id == 'CODE2':
+            self._app.reveal_topic('updateSquid')
+
         self.show_hints_message(code_msg_id)
 
         self.wait_for_app_js_props_changed(self._app, ['flipped', 'playing'])

--- a/eosclubhouse/quests/episode2/lightspeedenemyb2.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyb2.py
@@ -27,6 +27,8 @@ class LightSpeedEnemyB2(Quest):
            or self.debug_skip():
             return self.step_play
 
+        self._app.reveal_topic('spawnEnemy')
+
         self.show_hints_message('CODE')
 
         self.wait_for_app_js_props_changed(self._app, ['flipped', 'playing'])

--- a/eosclubhouse/quests/episode2/lightspeedenemyc1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyc1.py
@@ -36,6 +36,8 @@ class LightSpeedEnemyC1(Quest):
            or self.debug_skip():
             return self.step_play
 
+        self._app.reveal_topic('spawnEnemy')
+
         self.show_hints_message('CODE')
 
         self.wait_for_app_js_props_changed(self._app, ['flipped', 'playing'])

--- a/eosclubhouse/quests/episode2/lightspeedenemyc2.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyc2.py
@@ -12,6 +12,8 @@ class LightSpeedEnemyC2(Quest):
         self._app = LightSpeed()
 
     def step_begin(self):
+        self._app.reveal_topic('spawnEnemy')
+
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
             self.give_app_icon(self.APP_NAME)
@@ -26,6 +28,8 @@ class LightSpeedEnemyC2(Quest):
         if (not self._app.get_js_property('flipped') and self._app.get_js_property('playing')) \
            or self.debug_skip():
             return self.step_play
+
+        self._app.reveal_topic('updateBeam')
 
         self.show_hints_message('CODE')
 

--- a/eosclubhouse/quests/episode2/lightspeedfix1.py
+++ b/eosclubhouse/quests/episode2/lightspeedfix1.py
@@ -77,6 +77,8 @@ class LightSpeedFix1(Quest):
         if self._app.get_js_property('success') or self.debug_skip():
             return self.step_success
 
+        self._app.reveal_topic('spawnEnemy')
+
         self.show_hints_message('CODE')
         if self._app.get_js_property('flipped'):
             self.wait_for_app_js_props_changed(self._app, ['flipped'])

--- a/eosclubhouse/quests/episode2/lightspeedfix2.py
+++ b/eosclubhouse/quests/episode2/lightspeedfix2.py
@@ -12,6 +12,10 @@ class LightSpeedFix2(Quest):
         self._app = LightSpeed()
 
     def step_begin(self):
+        # Reveal this topic here, I guess? There's not really any other good
+        # place to reveal it, because it's never used in any of the quests.
+        self._app.reveal_topic('updateAsteroid')
+
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
             self.give_app_icon(self.APP_NAME)
@@ -30,6 +34,9 @@ class LightSpeedFix2(Quest):
 
     @Quest.with_app_launched(APP_NAME)
     def step_wait_for_flip(self, msg_id):
+        if msg_id == 'CODE':
+            self._app.reveal_topic('spawnEnemy')
+
         if not self._app.get_js_property('flipped') or self.debug_skip():
             self.wait_for_app_js_props_changed(self._app, ['flipped'])
         return self.step_code, msg_id


### PR DESCRIPTION
This adds keys to the game state, `lightspeed.topic.*` where `*` can be
`spawnEnemy`, `updateAsteroid`, `updateSpinner`, `updateSquid` or
`updateBeam`. We use the game state service to tell the toolbox to
reveal these topics the first time they are mentioned in each quest, or
at the beginning of the quest if the quest dialog just assumes they are
already revealed.

During normal traversal of the quests, these calls should only do
anything the first time they are encountered. Once topics are revealed,
there is currently nothing that un-reveals them. However, we make sure
to reveal everything we need in every quest where it's relevant. For
example, in case you debug-skip some quests.

The odd one out is the updateAsteroid function, which players will use
during their explorations but is never actually mentioned in any of the
quests. We reveal this one in the LightspeedFix2 quest, simply because
I can't think of a better place to do it, and LightSpeedFix1 already
reveals the spawnEnemy function so I don't want to do both at the same
time.

https://phabricator.endlessm.com/T25677