### PR TITLE
quests, libquest: Refactor updating availability

### DIFF
--- a/eosclubhouse/quests/episode1/breaksomething.py
+++ b/eosclubhouse/quests/episode1/breaksomething.py
@@ -10,19 +10,12 @@ class BreakSomething(Quest):
     CURSOR_NORMAL_SIZE = 24
     CURSOR_HUGE_SIZE = 200
 
+    __available_after_completing_quests__ = ['OSIntro']
+
     def __init__(self):
         super().__init__('Break Something', 'riley')
         self._app = App(self.APP_NAME)
-        self.gss.connect('changed', self.update_availability)
-        self.available = False
-        self.update_availability()
         self.settings = Gio.Settings.new("org.gnome.desktop.interface")
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("OSIntro"):
-            self.available = True
 
     def step_begin(self):
         if self._app.is_running():

--- a/eosclubhouse/quests/episode1/fizzics1.py
+++ b/eosclubhouse/quests/episode1/fizzics1.py
@@ -6,22 +6,15 @@ class Fizzics1(Quest):
 
     APP_NAME = 'com.endlessm.Fizzics'
 
+    __available_after_completing_quests__ = ['FizzicsIntro']
+
     def __init__(self):
         super().__init__('Fizzics 1', 'riley')
         self._app = App(self.APP_NAME)
-        self.gss.connect('changed', self.update_availability)
         self.already_in_level_8 = False
-        self.available = False
-        self.update_availability()
 
     def _app_is_flipped(self):
         return bool(self._app.get_js_property('flipped'))
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("FizzicsIntro"):
-            self.available = True
 
     def get_current_level(self):
         if self.debug_skip():

--- a/eosclubhouse/quests/episode1/fizzicscode2.py
+++ b/eosclubhouse/quests/episode1/fizzicscode2.py
@@ -6,19 +6,11 @@ class FizzicsCode2(Quest):
 
     APP_NAME = 'com.endlessm.Fizzics'
 
+    __available_after_completing_quests__ = ['FizzicsCode1']
+
     def __init__(self):
         super().__init__('Fizzics Code 2', 'riley')
         self._app = App(self.APP_NAME)
-        self.gss.connect('changed', self.update_availability)
-        self.available = False
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            self.set_next_episode('episode2')
-            return
-        if self.is_named_quest_complete("FizzicsCode1"):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():
@@ -60,5 +52,6 @@ class FizzicsCode2(Quest):
         Sound.play('quests/step-forward')
         self.conf['complete'] = True
         self.available = False
+        self.set_next_episode('episode2')
         Sound.play('quests/quest-complete')
         self.show_message('END', choices=[('Bye', self.stop)])

--- a/eosclubhouse/quests/episode1/hackdex1.py
+++ b/eosclubhouse/quests/episode1/hackdex1.py
@@ -6,19 +6,11 @@ class Hackdex1(Quest):
 
     APP_NAME = 'com.endlessm.Hackdex_chapter_one'
 
+    __available_after_completing_quests__ = ['BreakSomething', 'Roster']
+
     def __init__(self):
         super().__init__('Hackdex Corruption', 'saniel')
         self._app = App(self.APP_NAME)
-        self.gss.connect('changed', self.update_availability)
-        self.available = False
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("BreakSomething") and \
-           self.is_named_quest_complete("Roster"):
-            self.available = True
 
     def step_begin(self):
         self.gss.set('app.com_endlessm_Hackdex_chapter_one.corruption',

--- a/eosclubhouse/quests/episode1/lostfiles.py
+++ b/eosclubhouse/quests/episode1/lostfiles.py
@@ -4,19 +4,10 @@ from eosclubhouse.system import Sound
 
 class LostFiles(Quest):
 
+    __available_after_completing_quests__ = ['Hackdex1']
+
     def __init__(self):
         super().__init__('Lost Files', 'ada')
-        self.available = False
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        # TODO: Add delay before offering this quest. Maybe 10-30
-        # minutes after the Hackdex Corruption one?
-        if self.is_named_quest_complete("Hackdex1"):
-            self.available = True
 
     def step_begin(self):
         self.wait_confirm('EXPLANATION1')

--- a/eosclubhouse/quests/episode2/breakingin.py
+++ b/eosclubhouse/quests/episode2/breakingin.py
@@ -7,18 +7,11 @@ class BreakingIn(Quest):
     APP_NAME = 'com.endlessm.OperatingSystemApp'
     LEVEL2_LOCK = 'lock.OperatingSystemApp.2'
 
+    __available_after_completing_quests__ = ['MakeDevice']
+
     def __init__(self):
         super().__init__('BreakingIn', 'riley')
         self._app = App(self.APP_NAME)
-        self.available = False
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("MakeDevice"):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():

--- a/eosclubhouse/quests/episode2/investigation.py
+++ b/eosclubhouse/quests/episode2/investigation.py
@@ -7,19 +7,12 @@ class Investigation(Quest):
     APP_NAME = 'com.endlessm.OperatingSystemApp'
     LEVEL2_LOCK = 'lock.OperatingSystemApp.2'
 
+    __available_after_completing_quests__ = ['Chore']
+
     def __init__(self):
         super().__init__('Investigation', 'riley')
         self._app = App(self.APP_NAME)
         self._try_attempts = 0
-        self.available = False
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("Chore"):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():

--- a/eosclubhouse/quests/episode2/lightspeedenemya1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya1.py
@@ -7,19 +7,11 @@ class LightSpeedEnemyA1(Quest):
 
     APP_NAME = 'com.endlessm.LightSpeed'
 
+    __available_after_completing_quests__ = ['LightSpeedFix2', 'StealthDevice']
+
     def __init__(self):
         super().__init__('LightSpeedEnemyA1', 'ada')
         self._app = LightSpeed()
-        self.available = False
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("LightSpeedFix2") and \
-           self.is_named_quest_complete("StealthDevice"):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():

--- a/eosclubhouse/quests/episode2/lightspeedenemyb1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyb1.py
@@ -12,18 +12,11 @@ class LightSpeedEnemyB1(Quest):
     APP_NAME = 'com.endlessm.LightSpeed'
     SCREEN_HEIGHT = 1004
 
+    __available_after_completing_quests__ = ['LightSpeedEnemyA3']
+
     def __init__(self):
         super().__init__('LightSpeedEnemyB1', 'saniel')
         self._app = LightSpeed()
-        self.available = False
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("LightSpeedEnemyA3"):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():

--- a/eosclubhouse/quests/episode2/lightspeedenemyc1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyc1.py
@@ -7,18 +7,11 @@ class LightSpeedEnemyC1(Quest):
 
     APP_NAME = 'com.endlessm.LightSpeed'
 
+    __available_after_completing_quests__ = ['LightSpeedEnemyB2']
+
     def __init__(self):
         super().__init__('LightSpeedEnemyC1', 'riley')
         self._app = LightSpeed()
-        self.available = False
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("LightSpeedEnemyB2"):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():

--- a/eosclubhouse/quests/episode2/lightspeedfix1.py
+++ b/eosclubhouse/quests/episode2/lightspeedfix1.py
@@ -7,20 +7,11 @@ class LightSpeedFix1(Quest):
 
     APP_NAME = 'com.endlessm.LightSpeed'
 
+    __available_after_completing_quests__ = ['LightSpeedTweak']
+
     def __init__(self):
         super().__init__('LightSpeedFix1', 'saniel')
         self._app = LightSpeed()
-
-        self.available = False
-
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete("LightSpeedTweak"):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():

--- a/eosclubhouse/quests/episode2/makerintro.py
+++ b/eosclubhouse/quests/episode2/makerintro.py
@@ -7,19 +7,11 @@ class MakerIntro(Quest):
     APP_NAME = 'com.endlessm.Fizzics'
     GAME_PRESET = 1001
 
+    __available_after_completing_quests__ = ['Investigation']
+
     def __init__(self):
         super().__init__('MakerIntro', 'faber')
-        self.available = False
         self._app = App(self.APP_NAME)
-
-        self.gss.connect('changed', self.update_availability)
-        self.update_availability()
-
-    def update_availability(self, gss=None):
-        if self.conf['complete']:
-            return
-        if self.is_named_quest_complete('Investigation'):
-            self.available = True
 
     def step_begin(self):
         if not self._app.is_running():


### PR DESCRIPTION
Quests that depend on quests from other questset use the exact same
code snippet. This moves it to libquest. The quests can define which
other quests make it available with the class attribute
`__available_after_completing_quests__`.

https://phabricator.endlessm.com/T25487