### PR TITLE
quests: Fix ending the FizzicsCode1 quest

### DIFF
--- a/eosclubhouse/quests/episode1/fizzicscode1.py
+++ b/eosclubhouse/quests/episode1/fizzicscode1.py
@@ -88,4 +88,4 @@ class FizzicsCode1(Quest):
         self.conf['complete'] = True
         self.available = False
         Sound.play('quests/quest-complete')
-        self.show_message('END', choices=[('Bye', self.stop())])
+        self.show_message('END', choices=[('Bye', self.stop)])


### PR DESCRIPTION
It was calling the stop method directly, when assigning it to a user
choice (in a quest message), so the quest would be immediately stopped
at that point. This patch assigns the stop method to it, rather than
calling it.

https://phabricator.endlessm.com/T25779