### PR TITLE
quests: Use "complete" property instead of the conf dictionary

### DIFF
--- a/eosclubhouse/quests/cesdemo/fizzics2.py
+++ b/eosclubhouse/quests/cesdemo/fizzics2.py
@@ -49,7 +49,7 @@ class Fizzics2(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         self.give_item('item.key.fizzics.2')
         self.complete_current_episode()

--- a/eosclubhouse/quests/episode1/breaksomething.py
+++ b/eosclubhouse/quests/episode1/breaksomething.py
@@ -147,7 +147,7 @@ class BreakSomething(Quest):
         return self.step_reward
 
     def step_reward(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
 

--- a/eosclubhouse/quests/episode1/firstcontact.py
+++ b/eosclubhouse/quests/episode1/firstcontact.py
@@ -26,7 +26,7 @@ class FirstContact(Quest):
         return self._app.get_js_property('mode', default_value=0) >= 4
 
     def step_reward(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         self.stop()
 

--- a/eosclubhouse/quests/episode1/fizzics1.py
+++ b/eosclubhouse/quests/episode1/fizzics1.py
@@ -151,7 +151,7 @@ class Fizzics1(Quest):
         return self.step_hack
 
     def step_success(self, already_beat=False):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         msg_id = 'ALREADYBEAT' if already_beat else 'SUCCESS'

--- a/eosclubhouse/quests/episode1/fizzics2.py
+++ b/eosclubhouse/quests/episode1/fizzics2.py
@@ -49,7 +49,7 @@ class Fizzics2(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         self.give_item('item.key.hackdex1.1')
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode1/fizzicscode1.py
+++ b/eosclubhouse/quests/episode1/fizzicscode1.py
@@ -85,7 +85,7 @@ class FizzicsCode1(Quest):
 
     def step_end(self):
         Sound.play('quests/step-forward')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_message('END', choices=[('Bye', self.stop)])

--- a/eosclubhouse/quests/episode1/fizzicscode2.py
+++ b/eosclubhouse/quests/episode1/fizzicscode2.py
@@ -50,7 +50,7 @@ class FizzicsCode2(Quest):
 
     def step_end(self):
         Sound.play('quests/step-forward')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         self.set_next_episode('episode2')
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode1/fizzicsintro.py
+++ b/eosclubhouse/quests/episode1/fizzicsintro.py
@@ -100,7 +100,7 @@ class FizzicsIntro(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         self.show_message('END', choices=[('Bye', self.stop)])
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode1/hackdex1.py
+++ b/eosclubhouse/quests/episode1/hackdex1.py
@@ -74,7 +74,7 @@ class Hackdex1(Quest):
         self.show_confirm_message('SUCCESS', confirm_label='OK').wait()
 
         self.give_item('item.key.fizzics.2')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode1/lostfiles.py
+++ b/eosclubhouse/quests/episode1/lostfiles.py
@@ -18,7 +18,7 @@ class LostFiles(Quest):
 
     def finish_episode(self):
         Sound.play('quests/quest-complete')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         self.complete_current_episode()
         self.stop()

--- a/eosclubhouse/quests/episode1/osintro.py
+++ b/eosclubhouse/quests/episode1/osintro.py
@@ -87,7 +87,7 @@ class OSIntro(Quest):
         self.wait_for_one([confirm_action, app_changes_action])
 
         if self.confirmed_step():
-            self.conf['complete'] = True
+            self.complete = True
             self.available = False
             Sound.play('quests/quest-complete')
             return self.step_wrapup

--- a/eosclubhouse/quests/episode1/roster.py
+++ b/eosclubhouse/quests/episode1/roster.py
@@ -57,7 +57,7 @@ class Roster(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_message('END', choices=[('Bye', self.stop)])

--- a/eosclubhouse/quests/episode2/breakingin.py
+++ b/eosclubhouse/quests/episode2/breakingin.py
@@ -82,7 +82,7 @@ class BreakingIn(Quest):
             return
 
         Sound.play('quests/quest-complete')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         self.complete_current_episode()
         self.stop()

--- a/eosclubhouse/quests/episode2/chore.py
+++ b/eosclubhouse/quests/episode2/chore.py
@@ -64,7 +64,7 @@ class Chore(Quest):
 
     def step_end(self):
         self.give_item('item.key.OperatingSystemApp.2')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/investigation.py
+++ b/eosclubhouse/quests/episode2/investigation.py
@@ -69,7 +69,7 @@ class Investigation(Quest):
 
     def step_end(self):
         self.give_item('item.key.unknown_item')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/lightspeedenemya1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya1.py
@@ -57,7 +57,7 @@ class LightSpeedEnemyA1(Quest):
         return self.step_play
 
     def step_success(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/lightspeedenemya2.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya2.py
@@ -66,7 +66,7 @@ class LightSpeedEnemyA2(Quest):
         return self.step_success
 
     def step_success(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_confirm_message('SUCCESS', confirm_label='Bye').wait()

--- a/eosclubhouse/quests/episode2/lightspeedenemya3.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya3.py
@@ -73,7 +73,7 @@ class LightSpeedEnemyA3(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_confirm_message('END', confirm_label='Bye').wait()

--- a/eosclubhouse/quests/episode2/lightspeedenemya4.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya4.py
@@ -80,7 +80,7 @@ class LightSpeedEnemyA4(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_confirm_message('END', confirm_label='Bye').wait()

--- a/eosclubhouse/quests/episode2/lightspeedenemyb1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyb1.py
@@ -87,7 +87,7 @@ class LightSpeedEnemyB1(Quest):
         return self.step_wait_for_flip, code_msg_id
 
     def step_success(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/lightspeedenemyb2.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyb2.py
@@ -73,7 +73,7 @@ class LightSpeedEnemyB2(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/lightspeedenemyc1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyc1.py
@@ -58,7 +58,7 @@ class LightSpeedEnemyC1(Quest):
 
     @Quest.with_app_launched(APP_NAME)
     def step_success(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_confirm_message('SUCCESS', confirm_label='Bye').wait()

--- a/eosclubhouse/quests/episode2/lightspeedenemyc2.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemyc2.py
@@ -79,7 +79,7 @@ class LightSpeedEnemyC2(Quest):
         return self.step_playtest
 
     def step_success(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_confirm_message('SUCCESS', confirm_label='Bye').wait()

--- a/eosclubhouse/quests/episode2/lightspeedfix1.py
+++ b/eosclubhouse/quests/episode2/lightspeedfix1.py
@@ -89,7 +89,7 @@ class LightSpeedFix1(Quest):
         return self.step_code
 
     def step_success(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/lightspeedfix2.py
+++ b/eosclubhouse/quests/episode2/lightspeedfix2.py
@@ -73,7 +73,7 @@ class LightSpeedFix2(Quest):
         return self.step_wait_for_flip, 'CODE'
 
     def step_success(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/lightspeedintro.py
+++ b/eosclubhouse/quests/episode2/lightspeedintro.py
@@ -63,7 +63,7 @@ class LightSpeedIntro(Quest):
         self.wait_confirm('SUCCESS')
 
         self.give_item('item.key.lightspeed.1')
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/lightspeedtweak.py
+++ b/eosclubhouse/quests/episode2/lightspeedtweak.py
@@ -99,7 +99,7 @@ class LightSpeedTweak(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_confirm_message('END', confirm_label='Bye').wait()

--- a/eosclubhouse/quests/episode2/makedevice.py
+++ b/eosclubhouse/quests/episode2/makedevice.py
@@ -42,7 +42,7 @@ class MakeDevice(Quest):
         self.stop()
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')

--- a/eosclubhouse/quests/episode2/makerintro.py
+++ b/eosclubhouse/quests/episode2/makerintro.py
@@ -53,7 +53,7 @@ class MakerIntro(Quest):
         Sound.play('quests/quest-complete')
         self.show_confirm_message('THANKS', confirm_label='Bye').wait()
 
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         self.stop()

--- a/eosclubhouse/quests/episode2/makerquest.py
+++ b/eosclubhouse/quests/episode2/makerquest.py
@@ -31,7 +31,7 @@ class MakerQuest(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
         Sound.play('quests/quest-complete')
         self.show_confirm_message('END', confirm_label='Bye').wait()

--- a/eosclubhouse/quests/episode2/stealthdevice.py
+++ b/eosclubhouse/quests/episode2/stealthdevice.py
@@ -15,7 +15,7 @@ class StealthDevice(Quest):
         return self.step_end
 
     def step_end(self):
-        self.conf['complete'] = True
+        self.complete = True
         self.available = False
 
         Sound.play('quests/quest-complete')


### PR DESCRIPTION
Now that we have the "complete" property, we should use it instead of
conf['complete'].

Not related, but this will help with https://phabricator.endlessm.com/T25833 .