### PR TITLE
data: Add the desktop suffix to the AppData

### DIFF
--- a/data/com.endlessm.Clubhouse.appdata.xml
+++ b/data/com.endlessm.Clubhouse.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>com.endlessm.Clubhouse</id>
+  <id>com.endlessm.Clubhouse.desktop</id>
   <metadata_license>LicenseRef-proprietary</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
   <name>Clubhouse</name>


### PR DESCRIPTION
Without the desktop suffix, GNOME Software's plugins will not match the
right application, and thus the logic of including the right app object
as part of the Hack proxy app in g-s will not work.

https://phabricator.endlessm.com/T25856