### PR TITLE
libquest: Declare missing variable _QuestRunContext

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -246,6 +246,7 @@ class _QuestRunContext:
         self._timeout_handle = None
         self._cancellable = cancellable
         self._debug_actions = set()
+        self._current_waiting_loop = None
 
     def _cancel_and_close_loop(self, loop):
         if not loop.is_closed():


### PR DESCRIPTION
The _current_waiting_loop variable in _QuestRunContext had not been
declared in the class' constructor after the last clean up of the
patch. This caused of course an exception when trying to read the
variable the first time.

This patch implements that easy fix.

https://phabricator.endlessm.com/T25877