### PR TITLE
quests: Fix use of wrong message ID in LightSpeed Enemy A1

### DIFF
--- a/eosclubhouse/quests/episode2/lightspeedenemya1.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya1.py
@@ -35,7 +35,7 @@ class LightSpeedEnemyA1(Quest):
     @Quest.with_app_launched(APP_NAME)
     def step_changeenemy(self):
         if not self._app.get_js_property('flipped') or self.debug_skip():
-            self.show_hints_message('PLAY')
+            self.show_hints_message('PLAYTEST')
             return self.step_play
 
         self._app.reveal_topic('spawnEnemy')


### PR DESCRIPTION
It was using "PLAY" as the message, but it's been updated to
"PLAYTEST".

https://phabricator.endlessm.com/T25916