### PR TITLE
utils: Do not wrap code messages in mono-space font

### DIFF
--- a/eosclubhouse/utils.py
+++ b/eosclubhouse/utils.py
@@ -246,7 +246,7 @@ class SimpleMarkupParser:
         [re.compile(r'(_)(?=\S)(.+?)(?<=\S)\1', re.S), r'<i>\2</i>'],  # italics
         [re.compile(r'(~)(?=\S)(.+?)(?<=\S)\1', re.S), r'<s>\2</s>'],  # strikethrough
         [re.compile(r'(`)(?=\S)(.+?)(?<=\S)\1', re.S),  # inline code
-         r'<tt><span foreground="#E01E5A" background="#E9E9EB">\2</span></tt>'],
+         r'<span foreground="#E01E5A" background="#E9E9EB">\2</span>'],
     ]
 
     @classmethod


### PR DESCRIPTION
For some reason the Shell is not calculating the text size for the
Quest dialogs if they have font sizes that vary, which is the case
when using a mono-space font in code messages, and the result is that
there are ellipsis breaking the text automatically in the wrong place.

To avoid that, this patch removes the use of mono-space fonts and
instead just lets the text be colored.

https://phabricator.endlessm.com/T25800