### PR TITLE
quests: Corrupt Hackdex when the Hackdex1 quest becomes available

### DIFF
--- a/eosclubhouse/quests/episode1/hackdex1.py
+++ b/eosclubhouse/quests/episode1/hackdex1.py
@@ -9,12 +9,30 @@ class Hackdex1(Quest):
     __available_after_completing_quests__ = ['BreakSomething', 'Roster']
 
     def __init__(self):
+        self._is_corrupt_setup = False
+
         super().__init__('Hackdex Corruption', 'saniel')
         self._app = App(self.APP_NAME)
 
+    def update_availability(self, _gss=None):
+        super().update_availability()
+
+        if self._is_corrupt_setup:
+            return
+
+        # We override this method just so we set the Hackdex corruption state when the quest
+        # becomes available.
+        if self.available:
+            if not self._app_is_corrupted():
+                self.gss.set('app.com_endlessm_Hackdex_chapter_one.corruption',
+                             {'state': 'corrupted', 'color': ''})
+            self._is_corrupt_setup = True
+
+    def _app_is_corrupted(self):
+        data = self.gss.get('app.com_endlessm_Hackdex_chapter_one.corruption', {'state': None})
+        return data.get('state') == 'corrupted'
+
     def step_begin(self):
-        self.gss.set('app.com_endlessm_Hackdex_chapter_one.corruption',
-                     {'state': 'corrupted', 'color': ''})
         self.wait_confirm('PRELAUNCH')
 
         if not self._app.is_running():


### PR DESCRIPTION
The Hackdex app was being set as corrupted when the Hackdex1 quest
started, but since the corruption state ends up making the app quit,
this means that the quest advances and then gets aborted after the app
is quit.
This is a problem so this patch just moves the corruption state to when
the quest becomes available (giving the app more time to quit before
the quest is eventually started). This is still not a perfect solution
because the app takes around 8 seconds to be quit, so it's enough time
to launch the Clubhouse and quickly start this quest.

https://phabricator.endlessm.com/T25465