### PR TITLE
LightSpeed: Fix updateSpinnerCode property

### DIFF
--- a/eosclubhouse/quests/episode2/lightspeedenemya3.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya3.py
@@ -31,7 +31,7 @@ class LightSpeedEnemyA3(Quest):
         self._app.set_level(5)
 
         try:
-            self._app.set_object_property('view.JSContext.globalLevel5Parameters',
+            self._app.set_object_property('view.JSContext.globalParameters',
                                           'updateSpinnerCode',
                                           '''if (enemy.position.y < 1000)
     enemy.position.y = enemy.position.y - 10;''')


### PR DESCRIPTION
The variable updateSpinnerCode has changed inside the LightSpeed and now
it's in globalParameters.

This is related to this issue:
https://phabricator.endlessm.com/T25722

https://phabricator.endlessm.com/T25897