### PR TITLE
data: Add missing state in episode 2

### DIFF
--- a/data/episodes/game_states/episode2.json
+++ b/data/episodes/game_states/episode2.json
@@ -56,6 +56,9 @@
   "lock.OperatingSystemApp.1" : {
     "locked" : false
   },
+  "app.hack_toolbox.reset_button" : {
+    "visible" : true
+  },
   "lock.fizzics.1" : {
     "locked" : false
   },


### PR DESCRIPTION
A normal run of episode 1 should have the reset button of the toolbox
visible.

https://phabricator.endlessm.com/T25947