### PR TITLE
clubhouse: Fix displaying an item notification

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -618,7 +618,7 @@ class ClubhousePage(Gtk.EventBox):
             logger.debug('Failed to get item %s from DB', item_id)
             return
 
-        icon_name, _icon_used_name, item_name = item
+        icon_name, _icon_used_name, item_name = item[:3]
 
         notification = Gio.Notification()
         if text is None:


### PR DESCRIPTION
Due to recent changes in what information is returned by the
QuestItemDB get using its get_item method, there was an error when
trying to assign the values in order to display them in an item popup
message. This patch fixes that in a way that prevents errors if the
number of elements in an item increases again in the future.

https://phabricator.endlessm.com/T25962