### PR TITLE
Fix setting episode 2 after last quest of episode 1

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1140,12 +1140,12 @@ class Quest(GObject.GObject):
         return 'quest.'
 
     def load_conf(self):
-        self.conf['complete'] = self.is_named_quest_complete(self.__class__.__name__)
+        self.complete = self.is_named_quest_complete(self.__class__.__name__)
 
     def _get_complete(self):
         return self.conf['complete']
 
-    def _set_complete(self, is_complete):
+    def set_complete(self, is_complete):
         self.conf['complete'] = is_complete
 
     def save_conf(self):
@@ -1228,7 +1228,7 @@ class Quest(GObject.GObject):
                                  flags=GObject.ParamFlags.READWRITE |
                                  GObject.ParamFlags.EXPLICIT_NOTIFY)
 
-    complete = GObject.Property(_get_complete, _set_complete, type=bool, default=False,
+    complete = GObject.Property(_get_complete, set_complete, type=bool, default=False,
                                 flags=GObject.ParamFlags.READWRITE |
                                 GObject.ParamFlags.EXPLICIT_NOTIFY)
 

--- a/eosclubhouse/quests/episode1/fizzicscode2.py
+++ b/eosclubhouse/quests/episode1/fizzicscode2.py
@@ -12,6 +12,11 @@ class FizzicsCode2(Quest):
         super().__init__('Fizzics Code 2', 'riley')
         self._app = App(self.APP_NAME)
 
+    def set_complete(self, is_complete):
+        super().set_complete(is_complete)
+        if self.complete:
+            self.set_next_episode('episode2')
+
     def step_begin(self):
         if not self._app.is_running():
             self.show_hints_message('LAUNCH')
@@ -52,6 +57,5 @@ class FizzicsCode2(Quest):
         Sound.play('quests/step-forward')
         self.complete = True
         self.available = False
-        self.set_next_episode('episode2')
         Sound.play('quests/quest-complete')
         self.show_message('END', choices=[('Bye', self.stop)])


### PR DESCRIPTION
Make set_complete public in the Quest class, and override it in the
FizzicsCode2 quest. Also reuse set_complete in the load_conf
method. This way the episode will be set to Episode 2 any time this
quest is completed.

https://phabricator.endlessm.com/T26083