### PR TITLE
quests: Fix set_complete override in FizzicsCode2

### DIFF
--- a/eosclubhouse/quests/episode1/fizzicscode2.py
+++ b/eosclubhouse/quests/episode1/fizzicscode2.py
@@ -12,8 +12,9 @@ class FizzicsCode2(Quest):
         super().__init__('Fizzics Code 2', 'riley')
         self._app = App(self.APP_NAME)
 
+    @Quest.complete.setter
     def set_complete(self, is_complete):
-        super().set_complete(is_complete)
+        Quest.set_complete(self, is_complete)
         if self.complete:
             self.set_next_episode('episode2')
 


### PR DESCRIPTION
The set_complete override in FizzicsCode2 is not getting correctly
called when setting the property. This is because of how the GObject
properties are associated with their setters, so this patch ensures
that the FizzicsCode2 declares the set_complete method as the complete
property setter method.

https://phabricator.endlessm.com/T26083