### PR TITLE
quests: Delay the detection of the enemies in LightSpeedEnemyA2

### DIFF
--- a/eosclubhouse/quests/episode2/lightspeedenemya2.py
+++ b/eosclubhouse/quests/episode2/lightspeedenemya2.py
@@ -21,17 +21,10 @@ class LightSpeedEnemyA2(Quest):
         return self.step_wait_for_flip
 
     @Quest.with_app_launched(APP_NAME)
-    def step_wait_for_flip(self):
-        code_msg_id = 'CODE'
-
+    def step_wait_for_flip(self, msg_id='CODE'):
         if not self._app.get_js_property('flipped') or self.debug_skip():
-            enemy_count = self._app.get_js_property('enemyType1SpawnedCount', 0)
-
-            if enemy_count == 0:
-                code_msg_id = 'ADD_ENEMY_CODE'
-
             self.wait_for_app_js_props_changed(self._app, ['flipped'])
-        return self.step_code, code_msg_id
+        return self.step_code, msg_id
 
     @Quest.with_app_launched(APP_NAME)
     def step_code(self, msg_id):
@@ -68,7 +61,7 @@ class LightSpeedEnemyA2(Quest):
 
         if enemy_count == 0 or min_y > max_y:
             self.show_hints_message('NOENEMIES')
-            return self.step_wait_for_flip
+            return self.step_wait_for_flip, 'ADD_ENEMY_CODE'
         if min_y == max_y:
             self.show_hints_message('NOTMOVING')
             return self.step_wait_for_flip


### PR DESCRIPTION
The LightSpeedEnemyA2 quest was checking the number of spawned enemies
right after the app was launched, and at that moment it can be that no
enemy has been spawned yet, so the quest would assume that no enemies
were in fact created, and guide the users towards creating them.

This patch fixes that by delaying the enemy detection until the
application is flipped; this should give time for the application to
spawn some enemies. Of course if the spawn function waits for a long
time before spawning enemies, the detection may still fail, but we
should consider a good solution to work within reasonable time
delays/constraints anyway.

https://phabricator.endlessm.com/T25917