### PR TITLE
episodes: Import Gio

### DIFF
--- a/eosclubhouse/episodes.py
+++ b/eosclubhouse/episodes.py
@@ -1,5 +1,5 @@
 import os
-from gi.repository import Gdk, Gtk
+from gi.repository import Gdk, Gio, Gtk
 
 from eosclubhouse import config, utils, libquest
 


### PR DESCRIPTION
Gio is needed after 830145d, but it hadn't been imported with that
commit. This patch imports it.

https://phabricator.endlessm.com/T25407