### PR TITLE
clubhouse: Don't reset quest actions for every quest answer

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -810,12 +810,16 @@ class ClubhousePage(Gtk.EventBox):
         actions = self._actions
         action = self._actions.get(action_key)
 
-        self._reset_quest_actions()
-
         if action is None:
             logger.debug('Failed to get action for key %s', action_key)
             logger.debug('Current actions: %s', actions)
             return
+
+        # It's important to reset the quest actions only after the check above, as the same action
+        # can be triggered twice by clicking the Quest view button's very quickly, and in that case,
+        # the second time we could be resetting the actions when new ones have been added by the
+        # quests in the meanwhile.
+        self._reset_quest_actions()
 
         # Call the action
         callback, args = action[1], action[2:]


### PR DESCRIPTION
Whenever a button in the Quest Shell view is clicked, it will call an
action in the Clubhouse application and from there derive what is the
associated callback from the quest by checking a key.

After checking whether that key was associated or not, the actions map
was always getting reset; this is a problem because if a button is
clicked very quickly in the Quest Shell view, then the same action is
called twice, so the first time it is called, the actions are reset and
the quest may set up new actions, but the second time the action is
called, it would no longer exist in the actions map, but it'd still
reset it, thus losing any association of keys->callbacks and impeding a
quest from proceeding.

These patch fixes the mentioned issue by ensuring that the actions map
is only reset if the key that triggered the action does exist in it,
otherwise nothing (apart from a debug message) is done.

https://phabricator.endlessm.com/T26043