### PR TITLE
libquest: Fix assigning the episode-name in Quest

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -538,7 +538,7 @@ class Quest(GObject.GObject):
         super().__init__()
         self._name = name
 
-        self._episode_name = Registry.get_current_episode()
+        self._episode_name = Registry.get_loaded_episode_name()
 
         self._qs_base_id = self.get_default_qs_base_id()
         self._initial_msg = initial_msg


### PR DESCRIPTION
The episode-name variable was being assigned to the current episode
info (a dictionary) rather than the name.

This was a mistake in a cleanup before sending the commit in
fb6509fc8623375a4ce6c34094e20ecc327e7cba.

https://phabricator.endlessm.com/T26207