### PR TITLE
Move the highlight animation logic into the QuestSet

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -300,8 +300,6 @@ class QuestSetButton(Gtk.Button):
         super().__init__(halign=Gtk.Align.START,
                          relief=Gtk.ReliefStyle.NONE)
 
-        self._unhighlighted_animation = None
-
         self.get_style_context().add_class('quest-set-button')
 
         self._quest_set = quest_set
@@ -350,11 +348,8 @@ class QuestSetButton(Gtk.Button):
         highlighted_style = 'highlighted'
         style_context = self.get_style_context()
         if highlighted:
-            self._unhighlighted_animation = self._character.body_animation
-            self._character.body_animation = 'hi'
             style_context.add_class(highlighted_style)
         else:
-            self._character.body_animation = self._unhighlighted_animation
             style_context.remove_class(highlighted_style)
 
     position = GObject.Property(_get_position, type=GObject.TYPE_PYOBJECT)

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1278,12 +1278,15 @@ class QuestSet(GObject.GObject):
     __empty_message__ = 'Nothing to see here!'
 
     visible = GObject.Property(type=bool, default=True)
-    highlighted = GObject.Property(type=bool, default=False)
     body_animation = GObject.Property(type=str, default='idle')
+
+    HIGHLIGHTED_ANIMATION = 'hi'
 
     def __init__(self):
         super().__init__()
         self._position = self.__position__
+        self._unhighlighted_body_animation = self.body_animation
+        self._highlighted = False
 
         self._quest_objs = []
         for quest_class in self.__quests__:
@@ -1326,6 +1329,20 @@ class QuestSet(GObject.GObject):
     def get_position(self):
         return self._position
 
+    def _get_highlighted(self):
+        return self._highlighted
+
+    def _set_highlighted(self, highlighted):
+        self._highlighted = highlighted
+
+        if self.highlighted:
+            if self.body_animation != self.HIGHLIGHTED_ANIMATION:
+                self._unhighlighted_body_animation = self.body_animation
+                self.body_animation = self.HIGHLIGHTED_ANIMATION
+        else:
+            if self.body_animation == self.HIGHLIGHTED_ANIMATION:
+                self.body_animation = self._unhighlighted_body_animation
+
     def _update_highlighted(self, _current_quest=None):
         next_quest = self.get_next_quest()
         self.highlighted = next_quest is not None and next_quest.available
@@ -1346,3 +1363,5 @@ class QuestSet(GObject.GObject):
 
     def is_active(self):
         return self.visible and self.get_next_quest() is not None
+
+    highlighted = GObject.Property(_get_highlighted, _set_highlighted, type=bool, default=False)


### PR DESCRIPTION
The logic for setting up the highlighted animation (called "hi") stopped
working after started using the body-animation property for setting the
Character's animation with the same name.

These changes move that logic into the QuestSet, so both the highlighted
and body-animation properties are managed in the same place and this
also fixes the regression mentioned above.

https://phabricator.endlessm.com/T26167