### PR TITLE
episodes: Add needed GLib import

### DIFF
--- a/eosclubhouse/episodes.py
+++ b/eosclubhouse/episodes.py
@@ -1,5 +1,5 @@
 import os
-from gi.repository import Gdk, Gio, Gtk
+from gi.repository import Gdk, Gio, GLib, Gtk
 
 from eosclubhouse import config, libquest, logger, utils
 from eosclubhouse.system import Sound


### PR DESCRIPTION
The changes in 122f44f2232c6ac2f38381e7766d743086f7b600 use a
GLib.Error but that module didn't import GLib, so this patch just adds
that import.

https://phabricator.endlessm.com/T25954