### PR TITLE
quests: Check if ApplyFob* quest have been cancelled

### DIFF
--- a/eosclubhouse/quests/episode3/activatetrap.py
+++ b/eosclubhouse/quests/episode3/activatetrap.py
@@ -19,13 +19,13 @@ class ActivateTrap(Quest):
         for message in range(2, 6):
             self.wait_confirm('TRY{}'.format(message))
 
-        trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
+        if not self.is_cancelled():
+            trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
 
-        trap_questset.body_animation = 'transcoding-init'
+            trap_questset.body_animation = 'transcoding-init'
 
-        self.wait_confirm('TRANSCODING')
-
-        trap_questset.body_animation = 'transcoding'
+        if not self.wait_confirm('TRANSCODING').is_cancelled():
+            trap_questset.body_animation = 'transcoding'
 
         return self.step_success
 

--- a/eosclubhouse/quests/episode3/applyfob1.py
+++ b/eosclubhouse/quests/episode3/applyfob1.py
@@ -12,20 +12,20 @@ class ApplyFob1(Quest):
             self.show_hints_message('OPEN_CLUBHOUSE')
         self.connect_clubhouse_changes(['window-is-visible']).wait()
 
-        self.wait_confirm('APPLY')
+        if not self.wait_confirm('APPLY').is_cancelled():
+            trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
+            trap_questset.body_animation = 'panels1'
 
-        trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
-        trap_questset.body_animation = 'panels1'
-        if self.clubhouse_state.window_is_visible:
-            Sound.play('quests/episode3/trap/animations/panels')
+            self.gss.update('item.fob.1', {'used': True},
+                            value_if_missing={'consume_after_use': True})
 
-        self.gss.update('item.fob.1', {'used': True},
-                        value_if_missing={'consume_after_use': True})
+            if self.clubhouse_state.window_is_visible:
+                Sound.play('quests/episode3/trap/animations/panels')
 
-        self.wait_confirm('OPEN')
-        self.wait_confirm('RILEY1')
-        self.wait_confirm('RILEY2')
-        self.wait_confirm('RILEY3')
+            self.wait_confirm('OPEN')
+            self.wait_confirm('RILEY1')
+            self.wait_confirm('RILEY2')
+            self.wait_confirm('RILEY3')
 
         return self.step_success
 

--- a/eosclubhouse/quests/episode3/applyfob2.py
+++ b/eosclubhouse/quests/episode3/applyfob2.py
@@ -12,18 +12,18 @@ class ApplyFob2(Quest):
             self.show_hints_message('OPEN_CLUBHOUSE')
         self.connect_clubhouse_changes(['window-is-visible']).wait()
 
-        self.wait_confirm('APPLY')
+        if not self.wait_confirm('APPLY').is_cancelled():
+            trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
+            trap_questset.body_animation = 'panels2'
 
-        trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
-        trap_questset.body_animation = 'panels2'
-        if self.clubhouse_state.window_is_visible:
-            Sound.play('quests/episode3/trap/animations/panels')
+            self.gss.update('item.fob.2', {'used': True},
+                            value_if_missing={'consume_after_use': True})
 
-        self.gss.update('item.fob.2', {'used': True},
-                        value_if_missing={'consume_after_use': True})
+            if self.clubhouse_state.window_is_visible:
+                Sound.play('quests/episode3/trap/animations/panels')
 
-        self.wait_confirm('OPEN')
-        self.wait_confirm('RILEY')
+            self.wait_confirm('OPEN')
+            self.wait_confirm('RILEY')
 
         return self.step_success
 

--- a/eosclubhouse/quests/episode3/applyfob3.py
+++ b/eosclubhouse/quests/episode3/applyfob3.py
@@ -12,18 +12,18 @@ class ApplyFob3(Quest):
             self.show_hints_message('OPEN_CLUBHOUSE')
         self.connect_clubhouse_changes(['window-is-visible']).wait()
 
-        self.wait_confirm('APPLY')
+        if not self.wait_confirm('APPLY').is_cancelled():
+            trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
+            trap_questset.body_animation = 'panels3'
 
-        trap_questset = Registry.get_quest_set_by_name('TrapQuestSet')
-        trap_questset.body_animation = 'panels3'
-        if self.clubhouse_state.window_is_visible:
-            Sound.play('quests/episode3/trap/animations/panels')
+            self.gss.update('item.fob.3', {'used': True},
+                            value_if_missing={'consume_after_use': True})
 
-        self.gss.update('item.fob.3', {'used': True},
-                        value_if_missing={'consume_after_use': True})
+            if self.clubhouse_state.window_is_visible:
+                Sound.play('quests/episode3/trap/animations/panels')
 
-        self.wait_confirm('OPEN')
-        self.wait_confirm('RILEY')
+            self.wait_confirm('OPEN')
+            self.wait_confirm('RILEY')
 
         return self.step_success
 


### PR DESCRIPTION
In case the quests have been cancelled, the waiting for confirmation is
finished but with a cancelled state, so the quest should check for that
before proceeding with the normal logic (setting up the animation and
consuming the item).

https://phabricator.endlessm.com/T26263