### PR TITLE
apps: Prevent exception in Lightspeed.set_level

### DIFF
--- a/eosclubhouse/apps.py
+++ b/eosclubhouse/apps.py
@@ -117,6 +117,10 @@ class LightSpeed(App):
 
         levelCount = self.get_js_property('availableLevels')
 
+        # If there was a problem getting the property, then we just stop here.
+        if levelCount is None:
+            return False
+
         if levelCount < level:
             if not self.set_js_property('availableLevels', ('i', level)):
                 return False


### PR DESCRIPTION
If we try to set the level in the Lightspeed app but the app is not
running, then the method returns None, meaning we cannot compare that
result with a number (resulting in an uncaught exception).
To avoid that we just check that return value and early return if
needed.

https://phabricator.endlessm.com/T26283