### PR TITLE
quests: Declare that episode 3's next episode is episode 4

### DIFF
--- a/eosclubhouse/quests/episode3/__init__.py
+++ b/eosclubhouse/quests/episode3/__init__.py
@@ -14,3 +14,6 @@ def set_required_game_state():
         gss = GameStateService()
         for key, value in game_state.items():
             gss.set(key, value)
+
+
+NEXT_EPISODE = 'episode4'


### PR DESCRIPTION
For now we need to declare what the next episode is directly in the
"current" episode module, so this change is needed for the transition to
work.

https://phabricator.endlessm.com/T26420