### PR TITLE
libquest: Improve message error for inexistent message ID

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -509,6 +509,10 @@ class AsyncAction:
         self._state = state
 
 
+class NoMessageIdError(Exception):
+    pass
+
+
 class Quest(GObject.GObject):
 
     __gsignals__ = {
@@ -1032,6 +1036,10 @@ class Quest(GObject.GObject):
             # Fallback to the given info_id if no string was found
             if info is None:
                 info = QuestStringCatalog.get_info(info_id)
+
+            if info is None:
+                raise NoMessageIdError("Can't show message, the message ID " + info_id +
+                                       " is not in the catalog.")
 
             options.update(info)
 

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -1,0 +1,39 @@
+from eosclubhouse.libquest import Registry, Quest, QuestSet, NoMessageIdError
+from eosclubhouse.utils import QuestStringCatalog
+from clubhouseunittest import ClubhouseTestCase
+
+
+class PhonyQuest(Quest):
+
+    def __init__(self, quest_set):
+        super().__init__('PhonyQuest for {}'.format(quest_set), quest_set.get_character())
+        self.available = True
+
+    def step_begin(self):
+        print('Nothing to see here')
+
+
+class TestQuests(ClubhouseTestCase):
+
+    def setUp(self):
+        Registry.load_current_episode()
+
+    def test_show_message_can_raise_custom_error(self):
+        """Tests that Quests raise a custom error when a message ID is not in the catalog."""
+
+        class PhonyAlice(QuestSet):
+            __character_id__ = 'Alice'
+
+        quest = PhonyQuest(PhonyAlice)
+
+        string_catalog = QuestStringCatalog._csv_dict
+        QuestStringCatalog.set_key_value_from_csv_row(('PHONYQUEST_HELLO',
+                                                       '', '', '', '', ''),
+                                                      string_catalog)
+
+        # The short and full forms should not raise:
+        quest.show_message('HELLO')
+        quest.show_message('PHONYQUEST_HELLO')
+
+        with self.assertRaises(NoMessageIdError):
+            quest.show_message('INEXISTENT_MESSAGE')


### PR DESCRIPTION
show_message() now raises a custom error when the message ID given
isn't found in the catalog.

Also adds test coverage.

https://phabricator.endlessm.com/T26450