### PR TITLE
tools: Build local flatpak system-wide with branch custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ and install it in the user installation base, you can do:
 
 `./tools/build-local-flatpak.sh --install`
 
+This automatically switches the flatpak to a 'custom' branch. If you need to
+switch from this custom local built version to the previous stable or master
+version, you can do so with:
+
+`sudo flatpak make-current --system com.endlessm.Clubhouse stable`
+
 ### Coding Style
 
 The `run-lint` script can be used to verify the codebase's coding style.

--- a/tools/build-local-flatpak.sh
+++ b/tools/build-local-flatpak.sh
@@ -18,7 +18,7 @@ pushd "$source_dir"
 # This is hacky but until we need to keep git as the source type, then it's the less intrusive.
 GIT_CLONE_BRANCH=${GIT_CLONE_BRANCH:-'", "type": "dir'}
 REPO=${REPO:-repo}
-BRANCH=${BRANCH:-master}
+BRANCH=${BRANCH:-custom}
 
 sed -e "s|@GIT_CLONE_BRANCH@|${GIT_CLONE_BRANCH}|g" \
     -e "s|@BRANCH@|${BRANCH}|g" \
@@ -26,7 +26,7 @@ sed -e "s|@GIT_CLONE_BRANCH@|${GIT_CLONE_BRANCH}|g" \
   com.endlessm.Clubhouse.json.in > com.endlessm.Clubhouse.json
 
 # Add any extra options from the user to the flatpak-builder command (e.g. --install)
-flatpak-builder build --user --force-clean com.endlessm.Clubhouse.json --repo=${REPO} $@ || ret=$?
+flatpak-builder build --force-clean com.endlessm.Clubhouse.json --repo=${REPO} $@ || ret=$?
 
 popd
 


### PR DESCRIPTION
We are trying to unify the local builds for development of our flatpak
components to use a 'custom' branch in the system-wide
installation. Then is easy to switch between the different
stable/master/custom branches using `flatpak make-current`.