### PR TITLE
flatpak: Force gtk notification backend

### DIFF
--- a/com.endlessm.Clubhouse.json.in
+++ b/com.endlessm.Clubhouse.json.in
@@ -16,6 +16,8 @@
         "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf",
         "--talk-name=org.freedesktop.Flatpak",
+        "--talk-name=org.gtk.Notifications",
+        "--env=GNOTIFICATION_BACKEND=gtk",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "modules": [


### PR DESCRIPTION
The new version of xdg-desktop-portals filters notifications with
GFileIcon and we're using that to send the character animation path to
the shell.

This change will force the use of the gtk notification backend in glib
so we'll avoid the portals restriction for notifications and everything
will continue working as expected.

https://phabricator.endlessm.com/T25823