### PR TITLE
clubhouse: Add message ID to message debug log

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -625,9 +625,10 @@ class ClubhousePage(Gtk.EventBox):
     def _quest_item_given_cb(self, quest, item_id, text):
         self._shell_popup_item(item_id, text)
 
-    def _quest_message_cb(self, quest, message_txt, answer_choices, character_id, character_mood,
-                          sfx_sound, bg_sound):
-        logger.debug('Message: %s character_id=%s mood=%s choices=[%s]', message_txt, character_id,
+    def _quest_message_cb(self, quest, message_id, message_txt, answer_choices, character_id,
+                          character_mood, sfx_sound, bg_sound):
+        logger.debug('Message %s: %s character_id=%s mood=%s choices=[%s]', message_id, message_txt,
+                     character_id,
                      character_mood, '|'.join([answer for answer, _cb, *_args in answer_choices]))
 
         self._reset_quest_actions()

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -517,7 +517,8 @@ class Quest(GObject.GObject):
 
     __gsignals__ = {
         'message': (
-            GObject.SignalFlags.RUN_FIRST, None, (str, GObject.TYPE_PYOBJECT, str, str, str, str)
+            GObject.SignalFlags.RUN_FIRST, None, (str, str, GObject.TYPE_PYOBJECT,
+                                                  str, str, str, str)
         ),
         'item-given': (
             GObject.SignalFlags.RUN_FIRST, None, (str, str)
@@ -1063,7 +1064,10 @@ class Quest(GObject.GObject):
                 sfx_sound = self._main_open_dialog_sound
         bg_sound = options.get('bg_sound')
 
-        self.emit('message', options['txt'], possible_answers,
+        # @todo: We are passing all the fields of the message
+        # information here, so it would be better to pass the dict
+        # directly.
+        self.emit('message', info_id or '', options['txt'], possible_answers,
                   options.get('character_id') or self._main_character_id,
                   options.get('mood') or self._main_mood,
                   sfx_sound, bg_sound)


### PR DESCRIPTION
This is useful when debugging quests.

https://phabricator.endlessm.com/T26513