### PR TITLE
clubhouse: Close the Shell quest view when its buttons are clicked

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -864,6 +864,10 @@ class ClubhousePage(Gtk.EventBox):
         actions = self._actions
         action = self._actions.get(action_key)
 
+        # We close the popup once we get a response from the user, otherwise the dialog would just
+        # keep getting displayed until closed or replaced from elsewhere.
+        self._shell_close_popup_message()
+
         if action is None:
             logger.debug('Failed to get action for key %s', action_key)
             logger.debug('Current actions: %s', actions)


### PR DESCRIPTION
The Shell quest view's dialogs are intentionally kept visible even after
the user has clicked one of their action buttons. The idea was that this
way we control how long we want the dialog around from the Clubhouse,
instead of requiring extra changes to the Shell if some there are
different requirements for this. This was never followed up in the
Clubhouse though, and the result is that dialogs just hang there after
the user click one of their buttons until another dialog replaces them
or they're eventually dismissed. This is now an issue since we now have
quests that pause after a "confirm message" dialog meaning the dialogs
do not go away for a while.

This patch fixes that by closing the Shell dialogs immediately after
a user action is received.

https://phabricator.endlessm.com/T26513