### PR TITLE
quests: Ensure BreakingIn is not left in a blocked state

### DIFF
--- a/eosclubhouse/quests/episode2/breakingin.py
+++ b/eosclubhouse/quests/episode2/breakingin.py
@@ -15,6 +15,14 @@ class BreakingIn(Quest):
         super().__init__('BreakingIn', 'riley')
         self._app = App(self.APP_NAME)
 
+        # Make sure the quest is doable, if it was left incomplete but with Riley trapped (early
+        # aborted).
+        self._ensure_is_unblocked()
+
+    def _ensure_is_unblocked(self):
+        if not self.complete and self.gss.get('clubhouse.character.Riley', {}).get('in_trap'):
+            self.gss.set('clubhouse.character.Riley', {'in_trap': False})
+
     def step_begin(self):
         self.ask_for_app_launch(self._app, pause_after_launch=2)
         return self.step_explanation
@@ -83,3 +91,11 @@ class BreakingIn(Quest):
         self.complete = True
         self.available = False
         self.stop()
+
+    # Override the default finish
+    def run_finished(self):
+        super().run_finished()
+
+        # Make sure we don't leave the quest in a state there the quest is not finished but Riley
+        # is no longer available because of being in the trap.
+        self._ensure_is_unblocked()


### PR DESCRIPTION
Since the BreakingIn trap first sets the state so Riley is trapped, and
only then it proceeds to set the quest as complete. It may thus happen
that the quest is left incomplete but with a trapped Riley (running out
of battery, crash, etc.), which means the user can no longer start that
quest and thus cannot finish the episode after that.

This patch prevents that by detecting such a case (incomplete quest +
trapped Riley) when the quest is initialized or when it's finished, and
resets Riley's state so the user can start the quest again.

https://phabricator.endlessm.com/T26578