### PR TITLE
libquest: Only give an item if the quest is not cancelled

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1158,6 +1158,10 @@ class Quest(GObject.GObject):
         return self._last_bg_sound_uuid
 
     def give_item(self, item_name, notification_text=None, consume_after_use=False):
+        if self.is_cancelled():
+            logger.debug('Not giving item "%s" because the quest has been cancelled.', item_name)
+            return
+
         current_state = self.gss.get(item_name)
         if current_state is not None and current_state.get('used', False):
             logger.warning('Attempt to give item %s failed, it was already given and used',


### PR DESCRIPTION
Sometimes quests give items after using a "wait function" and without
checking whether the wait function succeeded or not. So if the quest is
cancelled, the wait function finishes the wait and thus any item given
after that is successfully given.

In order to prevent that, this patch ensures that the give_item method
first checks for whether the quest is cancelled, in which case it
doesn't give the item.

https://phabricator.endlessm.com/T26451