### PR TITLE
quests: Disable Fizzics toolbox in FizzicsKey

### DIFF
--- a/eosclubhouse/quests/episode4/fizzicskey.py
+++ b/eosclubhouse/quests/episode4/fizzicskey.py
@@ -1,5 +1,5 @@
 from eosclubhouse.libquest import Quest
-from eosclubhouse.system import Sound
+from eosclubhouse.system import Sound, ToolBoxTopic
 from eosclubhouse.apps import Fizzics
 
 
@@ -104,6 +104,8 @@ class FizzicsKey(Quest):
 
     def step_begin(self):
         self.ask_for_app_launch(self._app, pause_after_launch=2)
+        toolbox_topic = ToolBoxTopic(self._app.APP_NAME, 'main')
+        toolbox_topic.set_sensitive(False)
         return self.step_ingame
 
     @Quest.with_app_launched(Fizzics.APP_NAME)


### PR DESCRIPTION
In this quest the characters change the ball properties using
multiple-choice dialogues. The limitation effect is lost if the player
could flip the app and use the controls.

https://phabricator.endlessm.com/T26612