### PR TITLE
Ep4 sidetrack bugfix

### DIFF
--- a/eosclubhouse/quests/episode4/mazept1.py
+++ b/eosclubhouse/quests/episode4/mazept1.py
@@ -25,6 +25,8 @@ class MazePt1(Quest):
     def step_begin(self):
         self.ask_for_app_launch(self._app, pause_after_launch=2, message_id='LAUNCH_ADA')
         self._app.set_js_property('availableLevels', ('u', 23))
+        if self._app.get_js_property('highestAchievedLevel') > 1:
+            self._app.set_js_property('highestAchievedLevel', ('u', 1))
         self._reset_confirmed_messages()
         self.cutscene_played = False
         return self.step_play_level, False
@@ -56,9 +58,10 @@ class MazePt1(Quest):
                 self.show_hints_message('ROBOTS3')
         elif current_level == 10:
             message_id = self._get_unconfirmed_message(['MOREROBOTS'])
+        elif current_level == 13:
+            message_id = self._get_unconfirmed_message(['AUTO1'])
         elif current_level == 14:
             if not self.cutscene_played:
-                self.wait_confirm('AUTO1')
                 # felix destroys the controls here
                 self._app.set_js_property('controlsCutscene', ('b', True))
                 self.pause(1)
@@ -75,17 +78,15 @@ class MazePt1(Quest):
         elif current_level == 16:
             if level_changed:
                 self.show_hints_message('AUTO3')
-            elif level_succeed is True:
-                message_id = self._get_unconfirmed_message(['AUTO3_SUCCESS'])
             elif level_succeed is False:
                 message_id = self._get_unconfirmed_message(['AUTO3_FAILURE'])
         elif current_level == 17:
             message_id = self._get_unconfirmed_message([
-                'AUTO4_BACKSTORY',
+                'AUTO3_SUCCESS', 'AUTO4_BACKSTORY',
                 *('AUTO4_BACKSTORY{}'.format(i) for i in range(2, 11)),
             ])
         elif current_level == 18:
-            message_id = self._get_unconfirmed_message(['ONEJUMP'])
+            message_id = self._get_unconfirmed_message(['ONEJUMP_PRE', 'ONEJUMP'])
             if message_id is None:
                 self.show_hints_message('ONEJUMP_ADA')
         elif current_level == 19:

--- a/eosclubhouse/quests/episode4/mazept3.py
+++ b/eosclubhouse/quests/episode4/mazept3.py
@@ -1,7 +1,6 @@
 from eosclubhouse.libquest import Quest
 from eosclubhouse.system import Sound
 from eosclubhouse.apps import Sidetrack
-from eosclubhouse import logger
 
 
 class MazePt3(Quest):
@@ -13,7 +12,8 @@ class MazePt3(Quest):
     def step_begin(self):
         self.ask_for_app_launch(self._app, pause_after_launch=2, message_id='LAUNCH')
         self._app.set_js_property('availableLevels', ('u', 36))
-        logger.debug('available levels = %i', int(self._app.get_js_property('currentLevel')))
+        if self._app.get_js_property('highestAchievedLevel') > 36:
+            self._app.set_js_property('highestAchievedLevel', ('u', 28))
         return self.step_play_level
 
     @Quest.with_app_launched(Sidetrack.APP_NAME)
@@ -26,14 +26,17 @@ class MazePt3(Quest):
             self.wait_confirm('RILEYPUSH2')
             self.wait_confirm('RILEYPUSH3')
         if current_level == 29:
+            self.dismiss_message()
             self.show_hints_message('RILEYPUSH3_B')
         if current_level == 30:
+            self.dismiss_message()
             self.show_hints_message('RILEYPUSH3_C')
         if current_level == 31:
             for i in range(4, 10):
                 msgid = 'RILEYPUSH{}'.format(i)
                 self.wait_confirm(msgid)
         if current_level == 34:
+            self.dismiss_message()
             for message_id in ['DRAMA', 'DRAMA_FELIX', 'DRAMA_FABER', 'DRAMA_RILEY', 'DRAMA_ADA']:
                 self.wait_confirm(message_id)
         if current_level == 36:

--- a/eosclubhouse/quests/episode4/trapintro.py
+++ b/eosclubhouse/quests/episode4/trapintro.py
@@ -1,6 +1,6 @@
 from eosclubhouse.libquest import Quest
 from eosclubhouse.system import GameStateService
-# from eosclubhouse.apps import Sidetrack
+from eosclubhouse.apps import Sidetrack
 
 
 class TrapIntro(Quest):
@@ -8,11 +8,11 @@ class TrapIntro(Quest):
     def __init__(self):
         super().__init__('TrapIntro', 'trap')
         self._gss = GameStateService()
-        # self._app = Sidetrack()
+        self._app = Sidetrack()
 
     def step_begin(self):
         # silently install the app
-        # self.give_app_icon(self._app.dbus_name)
+        self.give_app_icon(self._app.dbus_name)
         # hide the trap
         self._gss.set('clubhouse.character.Trap', {'deployed': True})
         self.wait_confirm('QUESTION_ACCEPT')


### PR DESCRIPTION
Big spate of small bugfixes for Sidetrack, and preparation for the dialogue sync.
Fixes:
Delay before controls destruction CS
Felixnet escape / Riley run-off CS
Hackdex pickup and logic
Setting available / highest levels for each quest
Dialogue relocations and other minor fixes

Partially addresses dialogue desync.

Dialogue updates are required, but should be dropped before merging.

https://phabricator.endlessm.com/T26661