### PR TITLE
quests: Fix victory condition of BonusRound

### DIFF
--- a/eosclubhouse/quests/episode4/bonusround.py
+++ b/eosclubhouse/quests/episode4/bonusround.py
@@ -52,8 +52,16 @@ class BonusRound(Quest):
         elif current_level == 50:
             self.show_hints_message('LEVELS10')
             self.show_hints_message('LEVELS10_B')
-            self.wait_for_app_js_props_changed(self._app, ['currentLevel'])
-            return self.step_success
+            self.wait_for_app_js_props_changed(self._app, ['playing'])
+
+            current_level = int(self._app.get_js_property('currentLevel'))
+            playing = bool(self._app.get_js_property('playing'))
+            success = bool(self._app.get_js_property('success'))
+            if current_level == 50 and not playing and success:
+                return self.step_success
+
+            return self.step_inlevel
+
         self.wait_for_app_js_props_changed(self._app, ['currentLevel'])
         return self.step_inlevel
 


### PR DESCRIPTION
Waiting for the level number to change does not work here, because 50 is
the last level.

Instead, we wait for 'playing' to change (either we died or beat the
level) while 'success' is true (beat, not died) and 'currentLevel' is
still 50 (didn't go back to a previous level and beat that one.)

https://phabricator.endlessm.com/T26705