### PR TITLE
system: Debug when properties change

### DIFF
--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -344,6 +344,8 @@ class App:
             _notify_obj, notify_prop, value = params.unpack()
 
             if notify_prop in props and value != values[notify_prop]:
+                logger.debug('Property %s changed from %s to %s', notify_prop,
+                             values[notify_prop], value)
                 values[notify_prop] = value
                 js_property_changed_cb(*args)
 


### PR DESCRIPTION
This is useful for debugging quests, since we don't have a way yet to
retrieve the result after waiting for multiple properties.

https://phabricator.endlessm.com/T26699