### PR TITLE
tools: Restart the GSS in the build-local-flatpak script

### DIFF
--- a/tools/build-local-flatpak.sh
+++ b/tools/build-local-flatpak.sh
@@ -28,6 +28,12 @@ sed -e "s|@GIT_CLONE_BRANCH@|${GIT_CLONE_BRANCH}|g" \
 # Add any extra options from the user to the flatpak-builder command (e.g. --install)
 flatpak-builder build --user --force-clean com.endlessm.Clubhouse.json --repo=${REPO} $@ || ret=$?
 
+# Reload the GSS to make sure we have the freshest changes in case it was modified for testing
+# this Clubhouse build.
+echo
+echo Restarting the GSS
+gdbus call -e -d com.endlessm.GameStateService -o /com/endlessm/GameStateService -m com.endlessm.GameStateService.Reload > /dev/null
+
 popd
 
 exit $ret


### PR DESCRIPTION
The GSS now has a longer timeout so it can still be alive after a new
Clubhouse build is finished. This may impede a fresh test of the
Clubhouse with an updated GSS because the service may still be running
with the older version.

Thus, we simply ask the GSS to reload its conf every time we build the
Clubhouse locally.

https://phabricator.endlessm.com/T26730