### PR TITLE
quests: Fix last Sidetrack cutscene and goal condition

### DIFF
--- a/eosclubhouse/quests/episode4/mazept4.py
+++ b/eosclubhouse/quests/episode4/mazept4.py
@@ -25,7 +25,6 @@ class MazePt4(Quest):
     def step_begin(self):
         self.ask_for_app_launch(self._app, pause_after_launch=2, message_id='LAUNCH')
         self._app.set_js_property('willPlayFelixEscapeAnimation', ('b', False))
-        self.should_do_runoff = False
         if self._app.get_js_property('highestAchievedLevel') > 40:
             self._app.set_js_property('highestAchievedLevel', ('u', 36))
         self._app.set_js_property('availableLevels', ('u', 40))
@@ -51,38 +50,45 @@ class MazePt4(Quest):
         elif current_level == 40:
             message_id = self._get_unconfirmed_message([
                 'LEVELS5', 'LEVELS5_RILEY', 'LEVELS5_SANIEL'])
-            self._app.set_js_property('willPlayFelixEscapeAnimation', ('b', True))
-            self.should_do_runoff = True
         else:
             self.dismiss_message()
 
         actions = [self.connect_app_js_props_changes(self._app, ['currentLevel',
                                                                  'success',
-                                                                 'willPlayFelixEscapeAnimation',
-                                                                 'escapeCutscene'])]
+                                                                 'playing'])]
         if message_id is not None:
             actions.append(self.show_confirm_message(message_id))
 
         self.wait_for_one(actions)
 
+        new_level = self._app.get_js_property('currentLevel')
+        success = self._app.get_js_property('success')
+        playing = self._app.get_js_property('playing')
+
+        # Check if goal was reached:
+        if new_level == 40 and success and not playing:
+            return self.step_cutscene
+
         level_changed = False
         level_success = None
         if self.confirmed_step():
             self.confirmed_messages.append(message_id)
-        elif self.should_do_runoff and \
-                not self._app.get_js_property('willPlayFelixEscapeAnimation'):
-            self._app.set_js_property('escapeCutscene', ('b', True))
-        elif self.should_do_runoff and not self._app.get_js_property('escapeCutscene'):
-            return self.step_final
-        elif current_level != self._app.get_js_property('currentLevel'):
+        elif current_level != new_level:
             level_changed = True
             self._reset_confirmed_messages()
         else:
             # Current level hasn't changed, so either the player
             # completed the level or died:
-            level_success = self._app.get_js_property('success')
+            level_success = success
 
         return self.step_play_level, level_changed, level_success
+
+    @Quest.with_app_launched(Sidetrack.APP_NAME)
+    def step_cutscene(self):
+        self._app.set_js_property('willPlayFelixEscapeAnimation', True)
+        self._app.set_js_property('escapeCutscene', True)
+        self.wait_for_app_js_props_changed(self._app, ['escapeCutscene'])
+        return self.step_final
 
     @Quest.with_app_launched(Sidetrack.APP_NAME)
     def step_final(self):


### PR DESCRIPTION
The quest was automatically winning without even beating level 40. Now
the goal condition is clear. And when this level is beated, the quest
goes to a separate step_cutscene where the cutscene happens by
communicating with the app and monitoring until the playback finishes.

https://phabricator.endlessm.com/T26843