### PR TITLE
build: Ensure the test failures are included in the build log

### DIFF
--- a/com.endlessm.Clubhouse.json.in
+++ b/com.endlessm.Clubhouse.json.in
@@ -51,7 +51,7 @@
             ],
             "run-tests": true,
             "test-rule": "",
-            "test-commands": ["meson test --timeout-multiplier=10"],
+            "test-commands": ["meson test --timeout-multiplier=10 --print-errorlogs"],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
This patch ensures that the test results are printed in the build log,
otherwise it is difficult to understand what went wrong when the tests
break in the CI.

https://phabricator.endlessm.com/T26904