### PR TITLE
clubhouse: Change highlight if quest's in background/foreground

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -463,6 +463,7 @@ class ClubhousePage(Gtk.EventBox):
         if self._current_quest is None:
             return
 
+        self._current_quest.quest_set.highlighted = False
         self._message.reset()
         self._message.set_character(self._current_quest.get_main_character())
 
@@ -892,6 +893,7 @@ class ClubhousePage(Gtk.EventBox):
     def set_quest_to_background(self):
         if self._current_quest:
             self._current_quest.set_to_background()
+            self._current_quest.quest_set.highlighted = True
         else:
             # If the quest proposal dialog in the Shell has been dismissed, then we
             # should reset the "proposing_quest" flag.


### PR DESCRIPTION
In order to make sure the user is more aware that a quest is still
running, if a quest is set to the background, its character should be
highlighted, and the opposite when the quest is continued.

https://phabricator.endlessm.com/T26632