### PR TITLE
Add Hack mode switch to the main window

### DIFF
--- a/com.endlessm.Clubhouse.json.in
+++ b/com.endlessm.Clubhouse.json.in
@@ -13,11 +13,14 @@
         "--socket=session-bus",
         "--own-name=com.endlessm.Clubhouse",
         "--filesystem=xdg-run/dconf",
+        "--filesystem=host:ro",
+        "--nofilesystem=~/*",
         "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf",
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.gtk.Notifications",
         "--env=GNOTIFICATION_BACKEND=gtk",
+        "--env=XDG_DATA_DIRS=$XDG_DATA_DIRS:/run/host/usr/share",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "modules": [

--- a/data/main-window.ui
+++ b/data/main-window.ui
@@ -5,6 +5,33 @@
     <property name="halign">fill</property>
     <property name="valign">fill</property>
     <child type="overlay">
+      <object class="GtkBox">
+        <property name="orientation">horizontal</property>
+        <property name="visible">True</property>
+        <property name="halign">fill</property>
+        <property name="hexpand">True</property>
+        <property name="valign">start</property>
+        <property name="vexpand">True</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="label">Hack:</property>
+          </object>
+          <packing>
+            <property name="pack_type">start</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="main_window_switch_hack_mode">
+            <property name="visible">True</property>
+          </object>
+          <packing>
+            <property name="pack_type">start</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="overlay">
       <object class="GtkButtonBox">
         <property name="visible">True</property>
         <property name="halign">center</property>

--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -1407,6 +1407,8 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
 
             self.connect('realize', self._window_realize_cb)
 
+        self._shell_settings = Gio.Settings('org.gnome.shell')
+
         self.set_keep_above(True)
 
         self.clubhouse_page = ClubhousePage(self)
@@ -1443,6 +1445,12 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
 
         self._main_window_stack = builder.get_object('main_window_stack')
 
+        self._hack_switch = builder.get_object('main_window_switch_hack_mode')
+        self._hack_switch_handler = self._hack_switch.connect('notify::active',
+                                                              self._hack_mode_switch_activate_cb)
+        self._shell_settings.connect('changed::hack-mode-enabled', self._settings_changed_cb)
+        self._update_hack_mode_swith_state()
+
         self._clubhouse_button = builder.get_object('main_window_button_clubhouse')
         self._inventory_button = builder.get_object('main_window_button_inventory')
 
@@ -1454,6 +1462,19 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
             button.connect('clicked', self._page_switch_button_clicked_cb, page_id)
 
         self.add(builder.get_object('main_window_overlay'))
+
+    def _update_hack_mode_swith_state(self):
+        self._hack_switch.handler_block(self._hack_switch_handler)
+
+        self._hack_switch.set_active(self._shell_settings.get_boolean('hack-mode-enabled'))
+
+        self._hack_switch.handler_unblock(self._hack_switch_handler)
+
+    def _hack_mode_switch_activate_cb(self, switch, _pspec):
+        self._shell_settings.set_boolean('hack-mode-enabled', self._hack_switch.get_active())
+
+    def _settings_changed_cb(self, settings, _key):
+        self._update_hack_mode_swith_state()
 
     def _window_realize_cb(self, window):
         def _window_focus_out_event_cb(_window, _event):


### PR DESCRIPTION
Per Design plans, the Clubhouse should have a switch to enable/disable
the Hack mode. So these changes add that switch directly in the main
view without much styling for now, and hook it to the Shell settings.

https://phabricator.endlessm.com/T27181