### PR TITLE
clubhouse: Hide window on delete-event

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -1541,6 +1541,11 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
         self._ambient_sound_uuid = None
         self.connect('notify::visible', self._on_visibile_property_changed)
 
+        def _on_delete(widget, _event):
+            widget.hide()
+            return True
+        self.connect('delete_event', _on_delete)
+
         self._clubhouse_state = ClubhouseState()
 
     def continue_playing(self):


### PR DESCRIPTION
We shouldn't destroy the clubhouse application window on close instead
of that we should hide to be able to show the window again if the
clubhouse is called.

https://phabricator.endlessm.com/T27232