### PR TITLE
clubhouse: fix flatpak manifest

### DIFF
--- a/com.endlessm.Clubhouse.json.in
+++ b/com.endlessm.Clubhouse.json.in
@@ -35,7 +35,7 @@
           "sources": [
             {
               "type": "git",
-              "url": "https://github.com/endlessm/clippy.git",
+              "url": "https://github.com/endlessm/clippy.git"
             }
           ]
         },


### PR DESCRIPTION
Remove extra colon in clipy module.

https://phabricator.endlessm.com/T27356