### PR TITLE
clubhouse: Don't skip taskbar for clubhouse window

### DIFF
--- a/data/clubhouse-window.ui
+++ b/data/clubhouse-window.ui
@@ -6,7 +6,6 @@
     <property name="can_focus">False</property>
     <property name="resizable">False</property>
     <property name="window_position">center</property>
-    <property name="skip_taskbar_hint">True</property>
     <signal name="delete-event" handler="_on_delete" swapped="no"/>
     <signal name="notify::visible" handler="_on_visibile_property_changed" swapped="no"/>
     <child>


### PR DESCRIPTION
The skip_taskbar_hint causes some problems with the window visibility
on the shell overview mode, if this is true, the window won't be shown
if there's no other window there.

https://phabricator.endlessm.com/T27357