### PR TITLE
clubhouse: Run FirstContact if puzzle not completed and closed.

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2006,8 +2006,9 @@ class ClubhouseApplication(Gtk.Application):
 
     # D-Bus implementation
     def show(self, timestamp):
-        self._ensure_window()
-        self._show_and_focus_window(int(timestamp))
+        if not self._run_episode_autorun_quest_if_needed():
+            self._ensure_window()
+            self._show_and_focus_window(int(timestamp))
 
         return None
 


### PR DESCRIPTION
Currently, the GNOME Shell calls the D-Bus method
com.endlessm.Clubhouse.show to show the Clubhouse window. Instead
of just showing the window, check if there is any quest that
should run before.

https://phabricator.endlessm.com/T27394