### PR TITLE
hackapps: PulseFlipToHackButton as a property

### DIFF
--- a/eosclubhouse/hackapps.py
+++ b/eosclubhouse/hackapps.py
@@ -87,6 +87,28 @@ class HackableApp(GObject.Object):
             return False
         return True
 
+    def _get_pulse_flip_to_hack_button(self):
+        try:
+            variant = GLib.Variant('(ss)', (self._INTERFACE_NAME, 'PulseFlipToHackButton'))
+            return self.get_properties_proxy().call_sync('Get', variant,
+                                                         Gio.DBusCallFlags.NONE, -1, None)
+        except GLib.Error as e:
+            logger.error(e)
+        return None
+
+    def _set_pulse_flip_to_hack_button(self, value):
+        try:
+            variant = GLib.Variant('(ssv)', (self._INTERFACE_NAME,
+                                             'PulseFlipToHackButton',
+                                             GLib.Variant('b', value)))
+            self.get_properties_proxy().call_sync('Set', variant,
+                                                  Gio.DBusCallFlags.NONE, -1,
+                                                  None)
+        except GLib.Error as e:
+            logger.error(e)
+            return False
+        return True
+
     toolbox_visible = \
         GObject.Property(getter=_get_toolbox_visible,
                          setter=_set_toolbox_visible,
@@ -97,8 +119,11 @@ class HackableApp(GObject.Object):
         GObject.Property(getter=_get_app_id, type=str,
                          flags=GObject.ParamFlags.READABLE)
 
-    def pulse_flip_to_hack_button(self, enable):
-        return self.get_proxy().PulseFlipToHackButton('(b)', enable)
+    pulse_flip_to_hack_button = \
+        GObject.Property(getter=_get_pulse_flip_to_hack_button,
+                         setter=_set_pulse_flip_to_hack_button,
+                         type=object,
+                         flags=GObject.ParamFlags.READWRITE)
 
 
 class HackableAppsManager:

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -547,7 +547,7 @@ class App:
     def pulse_flip_to_hack_button(self, enable):
         app = HackableAppsManager.get_hackable_app(self._app_dbus_name)
         if app:
-            app.pulse_flip_to_hack_button(enable)
+            app.pulse_flip_to_hack_button = enable
 
     def enable_clippy(self, enable=True):
         sandbox = get_flatpak_sandbox()


### PR DESCRIPTION
As part of the shell PR to master we're changing the
PulseFlipToHackButton method to be a property. This patch updates the
code to adapt to the new shell code.

**Do not merge until we've the code updated in the hack2 branch: https://github.com/endlessm/gnome-shell/pull/516**

https://phabricator.endlessm.com/T27420