### PR TITLE
clubhouse: Check if org.gnome.shell schema exists

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -359,9 +359,7 @@ class QuestSetButton(Gtk.Button):
                                       GObject.BindingFlags.SYNC_CREATE)
         self._quest_set.bind_property('body-animation', self._character, 'body-animation',
                                       GObject.BindingFlags.SYNC_CREATE)
-        Desktop.get_shell_settings().bind(Desktop.SETTINGS_HACK_MODE_KEY,
-                                          self, 'sensitive',
-                                          Gio.SettingsBindFlags.DEFAULT)
+        Desktop.shell_settings_bind(Desktop.SETTINGS_HACK_MODE_KEY, self, 'sensitive')
 
     def reload(self, scale):
         self._scale = scale
@@ -509,8 +507,8 @@ class ClubhouseView(Gtk.EventBox):
 
         self.add_tick_callback(AnimationSystem.step)
 
-        Desktop.get_shell_settings().connect('changed::{}'.format(Desktop.SETTINGS_HACK_MODE_KEY),
-                                             self._settings_changed_cb)
+        Desktop.shell_settings_connect('changed::{}'.format(Desktop.SETTINGS_HACK_MODE_KEY),
+                                       self._settings_changed_cb)
         self._update_hack_mode_switch_state()
 
         self._gss = GameStateService()

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1629,9 +1629,8 @@ class CharacterMission(QuestSet):
         self._previous_body_animation = None
         self._highlighted = False
 
-        Desktop.get_shell_settings().connect('changed::{}'.format(Desktop.SETTINGS_HACK_MODE_KEY),
-                                             self._hack_mode_changed_cb)
-
+        Desktop.shell_settings_connect('changed::{}'.format(Desktop.SETTINGS_HACK_MODE_KEY),
+                                       self._hack_mode_changed_cb)
         for quest in self.get_quests():
             quest.connect('notify',
                           lambda quest, param: self.on_quest_properties_changed(quest, param.name))


### PR DESCRIPTION
When running tests before building a flatpak, tests try to look
for org.gnome.shell schema, but cannot find it, and then fails.

https://phabricator.endlessm.com/T27444