### PR TITLE
clubhouse: Hide buttons and characters on old messages

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -484,6 +484,10 @@ class CharacterView(Gtk.Grid):
             msg.display_character(True)
             msg.props.halign = Gtk.Align.END
 
+        # Hide actions on old messages.
+        for row in self._message_list.get_children()[:-1]:
+            row.get_child().clear_buttons()
+
         return msg
 
     def clear_messages(self):


### PR DESCRIPTION
The case on which multiple messages per character is considered.
In that case, we only kept the last message for a given character
showing the buttons and character.

https://phabricator.endlessm.com/T27406