### PR TITLE
clubhouse: stop_quest only if hack_mode_enabled is false

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -1699,7 +1699,6 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
             Desktop.set_hack_background(hack_mode_enabled)
         Desktop.set_hack_cursor(hack_mode_enabled)
         self._pathways_button.props.sensitive = hack_mode_enabled
-        self.clubhouse.stop_quest()
 
         ctx = self.get_style_context()
         ctx.add_class('transitionable-background')
@@ -1708,6 +1707,7 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
             ctx.remove_class('off')
         else:
             ctx.add_class('off')
+            self.clubhouse.stop_quest()
 
     def _update_window_size(self):
         BG_WIDTH = 1200


### PR DESCRIPTION
As part of the "cleanup off state classes" the running quest is been
stopped when the hack-mode-enabled change so for the first contact quest
the quest is cancelled after launch the HackUnclock app, because the
quest is ran and the hack-mode-enabled is modified inside that quest.

This patch fix this problem doing the quest stop only if the hack mode
is disabled.

https://phabricator.endlessm.com/T27478