### PR TITLE
Hack2 deploy: adjust for rename of the game state service

### DIFF
--- a/data/tools/eos-hack-reset-clubhouse
+++ b/data/tools/eos-hack-reset-clubhouse
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-echo "Resetting com.endlessm.GameStateService"
+echo "Resetting com.hack_computer.GameStateService"
 gdbus call --session \
-    --dest com.endlessm.GameStateService \
-    --object-path /com/endlessm/GameStateService \
-    --method com.endlessm.GameStateService.Reset
+    --dest com.hack_computer.GameStateService \
+    --object-path /com/hack_computer/GameStateService \
+    --method com.hack_computer.GameStateService.Reset
 
 echo "Resetting the hack-mode"
 gsettings reset org.gnome.shell hack-mode-enabled

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -604,9 +604,9 @@ class GameStateService(GObject.GObject):
             klass._proxy = Gio.DBusProxy.new_for_bus_sync(Gio.BusType.SESSION,
                                                           0,
                                                           None,
-                                                          'com.endlessm.GameStateService',
-                                                          '/com/endlessm/GameStateService',
-                                                          'com.endlessm.GameStateService',
+                                                          'com.hack_computer.GameStateService',
+                                                          '/com/hack_computer/GameStateService',
+                                                          'com.hack_computer.GameStateService',
                                                           None)
 
         return klass._proxy
@@ -660,7 +660,8 @@ class GameStateService(GObject.GObject):
 
     @staticmethod
     def _is_key_error(error):
-        return Gio.DBusError.get_remote_error(error) == 'com.endlessm.GameStateService.KeyError'
+        return Gio.DBusError.get_remote_error(error) ==\
+            'com.hack_computer.GameStateService.KeyError'
 
 
 class ToolBoxTopic(GObject.GObject):

--- a/katamari/com.endlessm.Clubhouse.json.in
+++ b/katamari/com.endlessm.Clubhouse.json.in
@@ -31,7 +31,7 @@
         "--filesystem=~/.local/share/flatpak",
         "--nofilesystem=~/.local/lib/python3.5",
         "--own-name=com.endlessm.Clubhouse",
-        "--own-name=com.endlessm.GameStateService",
+        "--own-name=com.hack_computer.GameStateService",
         "--own-name=com.endlessm.HackSoundServer",
         "--own-name=com.endlessm.HackToolbox",
         "--own-name=com.endlessm.HackUnlock",

--- a/katamari/tools/build-clubhouse
+++ b/katamari/tools/build-clubhouse
@@ -47,9 +47,9 @@ DEFAULTS = {
 
 def _reload_gss():
     run_command(['gdbus', 'call', '-e',
-                 '-d', 'com.endlessm.GameStateService',
-                 '-o', '/com/endlessm/GameStateService',
-                 '-m', 'com.endlessm.GameStateService.Reload'])
+                 '-d', 'com.hack_computer.GameStateService',
+                 '-o', '/com/hack_computer/GameStateService',
+                 '-m', 'com.hack_computer.GameStateService.Reload'])
 
 
 def _quit_clubhouse():

--- a/tests/clubhouseunittest.py
+++ b/tests/clubhouseunittest.py
@@ -29,7 +29,7 @@ class _GSSMockProxy(GObject.GObject):
         try:
             return self.__state__[key]
         except KeyError:
-            raise Gio.DBusError.new_for_dbus_error("com.endlessm.GameStateService.KeyError",
+            raise Gio.DBusError.new_for_dbus_error("com.hack_computer.GameStateService.KeyError",
                                                    "Phony KeyError")
 
     def Set(self, _variant_format, key, variant):


### PR DESCRIPTION
The game state service will use the com.hack_laptop domain name prefix.

Hack1 style episodes will not be affected from this change and keep on using the old game state service.

https://phabricator.endlessm.com/T27400