### PR TITLE
katamari: new param to produce manifest.json.in

### DIFF
--- a/katamari/tools/_clippy.py
+++ b/katamari/tools/_clippy.py
@@ -21,10 +21,10 @@ MODULES = [
 ]
 
 
-def main(config, only_manifest=False):
+def main(config, template=None):
     # Create the manifest:
-    create_flatpak_manifest(config, MODULES, MANIFEST_FILE)
-    if only_manifest:
+    create_flatpak_manifest(config, MODULES, MANIFEST_FILE, template)
+    if template:
         return
 
     repo = config.get('Advanced', 'repo')

--- a/katamari/tools/_common.py
+++ b/katamari/tools/_common.py
@@ -197,8 +197,13 @@ def _get_source(module, module_value, default_git_branch):
     return _get_git_source(git_url, module_value)
 
 
-def create_flatpak_manifest(config, modules, manifest):
+def create_flatpak_manifest(config, modules, manifest, template=None):
     template_values = config.get_template_values(modules)
+
+    manifest_file = manifest
+    if template:
+        template_values['BRANCH'] = '@BRANCH@'
+        manifest_file = template
 
     manifest_out = ''
     with open(manifest + '.in') as fd:
@@ -207,7 +212,7 @@ def create_flatpak_manifest(config, modules, manifest):
         # Removing comments to avoid problems with strict json
         manifest_out = re.sub(r'\s*\/\*\*.*\*\*\/', '', manifest_out)
 
-    with open(manifest, 'w') as fd:
+    with open(manifest_file, 'w') as fd:
         fd.write(manifest_out)
 
 
@@ -244,8 +249,8 @@ def run(main, *args, **kwargs):
     parser.add_argument('mode', nargs='?', choices=('print-config',),
                         metavar='MODE',
                         help='print-config: Print the parsed configuration.')
-    parser.add_argument('--manifest', action='store_true',
-                        help='Only generates the flatpak manifest file, do not build.')
+    parser.add_argument('--manifest-template',
+                        help='Only generates the flatpak template manifest in the desired location.')
     cli_args = parser.parse_args()
 
     # Run this script in the base directory:
@@ -261,7 +266,7 @@ def run(main, *args, **kwargs):
         sys.exit()
 
     try:
-        main(config, cli_args.manifest)
+        main(config, cli_args.manifest_template)
     except BuildError as error:
         sys.exit(error)
 

--- a/katamari/tools/build-clubhouse
+++ b/katamari/tools/build-clubhouse
@@ -64,10 +64,10 @@ def _quit_clubhouse():
     run_command(['flatpak', 'run', 'com.hack_computer.Clubhouse', '--quit'], env=env)
 
 
-def main(config, only_manifest=False):
+def main(config, template=None):
     # Create the manifest:
-    create_flatpak_manifest(config, MODULES, MANIFEST_FILE)
-    if only_manifest:
+    create_flatpak_manifest(config, MODULES, MANIFEST_FILE, template)
+    if template:
         return
 
     repo = config.get('Advanced', 'repo')


### PR DESCRIPTION
The CI builds the flatpak but needs to specify the flatpak branch
depending, there's a tool to build json.in with the `@BRANCH@` variable so
the CI will replace that. This new parameter will allow us to build in
the json.in required by the jenkins script.

Right now the tests with the CI are working, we've been able to build clubhouse, but it's always built with the `custom` flatpak branch so the `clippy` CI build is not able to find the corresponding clubhouse in the `eos-apps` repository. Right now you can find the `Clubhouse//custom` in that repo.

The idea is to use:
```
      - clubhouse:
          repo: clubhouse
          prepare_script: "katamari/tools/build-clubhouse --manifest-template com.hack_computer.Clubhouse.json.in"
          manifest: com.hack_computer.Clubhouse.json.in
```

https://phabricator.endlessm.com/T27400