### PR TITLE
clubhouse: Remove message/dialogue close button

### DIFF
--- a/data/gtk-style.css
+++ b/data/gtk-style.css
@@ -168,16 +168,6 @@ window.CHARACTER {
     background: white;
 }
 
-.character-message-side-button {
-    background: transparent;
-    color: #8A6A45;
-    border: none;
-    border-radius: 0;
-    margin: 0;
-    padding: 5px 5px 0 0;
-    box-shadow: none;
-}
-
 .clubhouse-button-box > button {
     border: none;
     box-shadow: none;

--- a/data/message.ui
+++ b/data/message.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <template class="Message" parent="GtkOverlay">
@@ -29,32 +29,6 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="close_button">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="halign">end</property>
-            <property name="valign">start</property>
-            <signal name="clicked" handler="_close_button_clicked_cb" swapped="no"/>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="pixel_size">16</property>
-                <property name="icon_name">window-close-symbolic</property>
-              </object>
-            </child>
-            <style>
-              <class name="character-message-side-button"/>
-            </style>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
           </packing>
         </child>
         <style>

--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -180,16 +180,9 @@ class Message(Gtk.Overlay):
 
     __gtype_name__ = 'Message'
 
-    __gsignals__ = {
-        'closed': (
-            GObject.SignalFlags.RUN_FIRST, None, ()
-        ),
-    }
-
     _label = Gtk.Template.Child()
     _character_image = Gtk.Template.Child()
     _button_box = Gtk.Template.Child()
-    close_button = Gtk.Template.Child()
 
     OPEN_DIALOG_SOUND = 'clubhouse/dialog/open'
 
@@ -199,10 +192,6 @@ class Message(Gtk.Overlay):
         self._character_mood_change_handler = 0
         self._animator = Animator(self._character_image)
         self.connect("show", lambda _: Sound.play('clubhouse/dialog/open'))
-
-    @Gtk.Template.Callback()
-    def _close_button_clicked_cb(self, button):
-        self.close()
 
     def set_text(self, txt):
         self._label.set_markup(SimpleMarkupParser.parse(txt))
@@ -239,14 +228,6 @@ class Message(Gtk.Overlay):
         for child in self._button_box:
             child.destroy()
         self._button_box.hide()
-
-    def close(self):
-        if not self.is_visible():
-            return
-
-        self.hide()
-        Sound.play('clubhouse/dialog/close')
-        self.emit('closed')
 
     def display_character(self, display):
         self._character_image.props.visible = display


### PR DESCRIPTION
Closing narrative dialogues may break the narrative quests, in
special when the message has actions, because you have no way to
continue.

Lord Saniel has ordered me to remove the close button.

https://phabricator.endlessm.com/T27548