### PR TITLE
Data: Add System app to whitelist

### DIFF
--- a/data/hack-data.ini
+++ b/data/hack-data.ini
@@ -10,4 +10,4 @@ blacklist=chromium-browser,com.google.Chrome,google-chrome,org.gnome.Eolie,org.g
 # be hackable all the time.
 # If the whitelist is empty or not present, then it will be ignored and all apps
 # not in the blacklist will once again be hackable.
-whitelist=com.endlessm.dinosaurs.en,com.endlessm.encyclopedia.en,com.hack_computer.Fizzics,com.hack_computer.Hackdex_chapter_one,com.hack_computer.Hackdex_chapter_two,com.hack_computer.HackUnlock,com.hack_computer.LightSpeed,com.hack_computer.OperatingSystemApp,com.hack_computer.Sidetrack,com.endlessm.Sketchbook
+whitelist=com.endlessm.dinosaurs.en,com.endlessm.encyclopedia.en,com.hack_computer.Fizzics,com.hack_computer.Hackdex_chapter_one,com.hack_computer.Hackdex_chapter_two,com.hack_computer.HackUnlock,com.hack_computer.LightSpeed,com.endlessm.OperatingSystemApp,com.hack_computer.OperatingSystemApp,com.hack_computer.Sidetrack,com.endlessm.Sketchbook

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -48,6 +48,7 @@ class Desktop:
         'com.hack_computer.Hackdex_chapter_two',
         'com.hack_computer.LightSpeed',
         'com.hack_computer.OperatingSystemApp',
+        'com.endlessm.OperatingSystemApp',
         'com.hack_computer.Sidetrack',
     ]
 


### PR DESCRIPTION
We need the System app with the endlessm.com domain to
be added to the whitelist for FtH and create the local
override for the app to point to the Clippy module.

https://phabricator.endlessm.com/T27537