### PR TITLE
clubhouse: Disable quest row if the respective quest runs

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -291,6 +291,9 @@ class QuestRow(Gtk.ListBoxRow):
         self._quest = quest
         self._has_category = has_category
 
+        self._quest.connect('quest-started', self._on_quest_started)
+        self._quest.connect('quest-finished', self._on_quest_finished)
+
         # Populate row info.
         self._setup_category_image()
         self._name_label.props.label = self._quest.get_name()
@@ -318,6 +321,12 @@ class QuestRow(Gtk.ListBoxRow):
     def _setup_difficulty_image(self):
         basename = self._quest.get_difficulty().name
         self._difficulty_image.props.icon_name = 'clubhouse-difficulty-{}'.format(basename.lower())
+
+    def _on_quest_started(self, quest):
+        self.props.sensitive = False
+
+    def _on_quest_finished(self, quest):
+        self.props.sensitive = True
 
     def _on_quest_complete_changed(self, _quest_set, _param):
         self._set_complete()

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -599,6 +599,12 @@ class Quest(GObject.GObject):
     MessageType = Enum('MessageType', ['POPUP', 'NARRATIVE'])
 
     __gsignals__ = {
+        'quest-started': (
+            GObject.SignalFlags.RUN_FIRST, None, ()
+        ),
+        'quest-finished': (
+            GObject.SignalFlags.RUN_FIRST, None, ()
+        ),
         'message': (
             GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)
         ),
@@ -803,12 +809,13 @@ class Quest(GObject.GObject):
         self.reset_hints_given_once()
 
         self._run_context = _QuestRunContext(self._cancellable)
+        self.emit('quest-started')
         self._run_context.run(self.step_begin)
         self._run_context = None
 
         self.run_finished()
-
         quest_finished_cb(self)
+        self.emit('quest-finished')
 
         # The quest is stopped, so reset the "stopping" property again.
         self.stopping = False


### PR DESCRIPTION
The signals quest-start and quest-finished to easily track the
row linked to a quest and disable or enable it regarding if
started or finished, respectively.

https://phabricator.endlessm.com/T27558