### PR TITLE
clubhouse: Prevent narrative message label to take image space

### DIFF
--- a/data/message.ui
+++ b/data/message.ui
@@ -56,7 +56,6 @@
     </child>
     <child type="overlay">
       <object class="GtkImage" id="_character_image">
-        <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">end</property>
         <property name="valign">end</property>


### PR DESCRIPTION
https://phabricator.endlessm.com/T27590