### PR TITLE
T27539 - 2nd pass of Meet The Clubhouse / First Contact

### DIFF
--- a/eosclubhouse/quests/hack2/firstcontact.py
+++ b/eosclubhouse/quests/hack2/firstcontact.py
@@ -96,12 +96,7 @@ class FirstContact(Quest):
 
     @Quest.with_app_launched(APP_NAME)
     def step_wait_for_flipback(self):
-        self.show_message('FLIPBACK')
-
-        if not self._is_app_flipped_back():
-            self.wait_for_app_js_props_changed(self._app, ['mode'], timeout=8)
-            if not self._is_app_flipped_back():
-                self.show_message('FLIPBACK_HINT1')
+        self.show_message('FLIPBACK_HINT1')
 
         while not self._is_app_flipped_back() and not self.is_cancelled():
             self.wait_for_app_js_props_changed(self._app, ['mode'])

--- a/eosclubhouse/quests/hack2/meet.py
+++ b/eosclubhouse/quests/hack2/meet.py
@@ -47,22 +47,26 @@ class Meet(Quest):
         # explain the profile
         for msgid in ['EXPLAIN_PROFILE1', 'EXPLAIN_PROFILE2', 'EXPLAIN_PROFILE3']:
             self.wait_confirm(msgid)
-        # ask if player wants to change their name
-        showme = ('CHANGE_NAME_YES', self.step_changename, True)
-        notnow = ('CHANGE_NAME_NO', self.step_changename, False)
-        # this function needs a wait() to prevent a hang after the callback
-        self.show_choices_message('CHANGE_NAME_ASK', showme, notnow).wait()
-        return self.step_end
 
-    def step_changename(self, result):
-        if result:
+        # ask if player wants to change their name
+        def _choice(choice_var):
+            return choice_var
+
+        action = self.show_choices_message('CHANGE_NAME_ASK', ('CHANGE_NAME_YES', _choice, True),
+                                           ('CHANGE_NAME_NO', _choice, False)).wait()
+        choice = action.future.result()
+
+        if choice:
             for msgid in ['CHANGE_NAME1', 'CHANGE_NAME2', 'CHANGE_NAME3']:
                 self.wait_confirm(msgid)
 
-    def step_end(self):
         self.wait_confirm('END1')
         self.wait_confirm('END2')
+        self.show_message('END3', choices=[('Got it!', self.step_end)])
+        return self.step_end
+
+    def step_end(self):
         self.complete = True
         self.available = False
-        self.show_message('END3', choices=[('Got it!', self.stop)])
         Sound.play('quests/quest-complete')
+        self.stop()

--- a/eosclubhouse/quests/hack2/quickstart.py
+++ b/eosclubhouse/quests/hack2/quickstart.py
@@ -1,0 +1,32 @@
+from eosclubhouse.libquest import Quest
+from eosclubhouse.system import Sound
+
+
+class Quickstart(Quest):
+
+    __quest_name__ = 'Tutorial - The Clubhouse'
+    __tags__ = ['mission:ada']
+    __mission_order__ = 10
+
+    def step_begin(self):
+        self.wait_confirm('WELCOME1')
+
+        def _choice(choice_var):
+            return choice_var
+
+        action = self.show_choices_message('WELCOME2', ('POSITIVE', _choice, True),
+                                           ('NEGATIVE', _choice, False)).wait()
+        choice = action.future.result()
+
+        if choice:
+            for msgid in ['HACKSWITCH', 'PATHWAYS1', 'PATHWAYS2', 'PROFILE1', 'PROFILE2']:
+                self.wait_confirm(msgid)
+
+        self.wait_confirm('END1')
+        self.show_message('END2', choices=[('Got it!', self.step_end)])
+
+    def step_end(self):
+        self.complete = True
+        self.available = False
+        Sound.play('quests/quest-complete')
+        self.stop()


### PR DESCRIPTION
- Some minor dialogue tweaks based on playtest feedback (will be integrated by Jenkins)
- Added a 'quickstart' version of Meet the Clubhouse, accessible as a recap of the initial tutorial.
- Removed an extraneous dialogue line from First Contact
- 'Attract' modes are still not in, that will require a 3rd pass.

https://phabricator.endlessm.com/T27539