### PR TITLE
clubhouse: Check character_id in CharacterView

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -519,7 +519,7 @@ class CharacterView(Gtk.Grid):
             min(overlay_width, max(self.MIN_MESSAGE_WIDTH,
                                    overlay_width * self.MIN_MESSAGE_WIDTH_RATIO))
 
-        if message_info.get('character_id') == current_quest.get_main_character():
+        if message_info.get('character_id') == self._character.id:
             msg.display_character(False)
             msg.props.halign = Gtk.Align.START
         else:


### PR DESCRIPTION
We've the character stored in the CharacterView object, so it's not
needed to query the quest for the main_character, the main character in
this case is always the character that's shown.

https://phabricator.endlessm.com/T27514