### PR TITLE
quests: Adding first-pass Blender 'advanced app' quest

### DIFF
--- a/eosclubhouse/quests/hack2/blenderquest.py
+++ b/eosclubhouse/quests/hack2/blenderquest.py
@@ -1,0 +1,68 @@
+from eosclubhouse.libquest import Quest
+from eosclubhouse.system import App
+
+
+class BlenderQuest(Quest):
+
+    APP_NAME = 'org.blender.Blender'
+
+    __quest_name__ = '3D Modeling for Beginners'
+    __tags__ = ['mission:estelle', 'pathway:maker', 'difficulty:hard']
+    __mission_order__ = 100
+    __pathway_order__ = 100
+
+    def setup(self):
+        self._app = App(self.APP_NAME)
+        self.NUM_INFO_MESSAGES = 4
+
+    def step_begin(self):
+        if not self._app.is_installed():
+            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
+            return self.step_abort
+
+        self.wait_confirm('WARN1')
+        self.wait_confirm('WARN2')
+
+        def _choice(choice_var):
+            return choice_var
+
+        action = self.show_choices_message('START_ASK', ('START_YES', _choice, True),
+                                           ('START_NO', _choice, False)).wait()
+        choice = action.future.result()
+
+        if choice:
+            self.wait_confirm('LAUNCH')
+            self._app.launch()
+            self.pause(4)
+            return self.step_info_loop
+        return self.step_complete_and_stop
+
+    def step_info_loop(self, message_index=1):
+        if message_index > self.NUM_INFO_MESSAGES:
+            message_index = 1
+        elif message_index < 1:
+            message_index = self.NUM_INFO_MESSAGES
+
+        message_id = 'INFO_' + str(message_index)
+
+        def _action_choice(action_choice_var):
+            return action_choice_var
+
+        if message_index == self.NUM_INFO_MESSAGES:
+            action = self.show_choices_message(message_id,
+                                               ('BAK', _action_choice, -1),
+                                               ('FWD', _action_choice, 1),
+                                               ('QUIT', _action_choice, 0)).wait()
+        else:
+            action = self.show_choices_message(message_id,
+                                               ('BAK', _action_choice, -1),
+                                               ('FWD', _action_choice, 1)).wait()
+
+        chosen_action = action.future.result()
+
+        if chosen_action == 0:
+            self.wait_confirm('BYE')
+            return self.step_complete_and_stop
+        else:
+            message_index += chosen_action
+            return self.step_info_loop, message_index


### PR DESCRIPTION
Now with new 'info-loop' technology
- supports back/fwd navigation
- supports clean quit at end

Currently does not detect app run/quit/start - Blender is not a GTK app, so we cannot use existing tech for this. TBD whether it's worth it.

https://phabricator.endlessm.com/T27739