### PR TITLE
flatpak: Give direct dconf access

### DIFF
--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -43,6 +43,7 @@
         "--socket=x11",
         "--system-talk-name=org.freedesktop.Accounts",
         "--system-talk-name=com.endlessm.Metrics",
+        "--talk-name=ca.desrt.dconf",
         "--talk-name=com.endlessm.Libanimation",
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.gtk.Notifications"


### PR DESCRIPTION
We need direct access to be able to update the shell settings about the
hack-mode-enabled.

See
http://docs.flatpak.org/en/latest/sandbox-permissions.html#dconf-access
for more information

https://phabricator.endlessm.com/T27910