### PR TITLE
quests: Switching quickstart/meet to have the shorter one be the intro

### DIFF
--- a/eosclubhouse/quests/hack2/meet.py
+++ b/eosclubhouse/quests/hack2/meet.py
@@ -1,32 +1,19 @@
 from eosclubhouse.libquest import Quest
-from eosclubhouse.system import Sound
 
 
 class Meet(Quest):
 
-    __quest_name__ = 'DEBUG NAME - Meet - DEBUG NAME'
+    __quest_name__ = 'Tutorial - The Clubhouse'
     __tags__ = ['mission:ada']
-    __auto_offer_info__ = {'confirm_before': False, 'start_after': 3}
-    __available_after_completing_quests__ = ['FirstContact']
-
-    def setup(self):
-        self.auto_offer = True
-        # Hide quest in UI
-        self.skippable = True
+    __mission_order__ = 10
 
     def step_begin(self):
         self.wait_confirm('WELCOME1')
         self.wait_confirm('WELCOME2')
-        # check to see if the player got a hint in the initial puzzle
-        # (this is intended to reward existing users who know the puzzle from hack 1.0)
-        if self.get_named_quest_conf('FirstContact', 'puzzle_hint_given'):
-            msg_id = 'WELCOME3_GOTHINT'
-        else:
-            msg_id = 'WELCOME3_NOHINT'
-        self.wait_confirm(msg_id)
         return self.step_mainwindow
 
     def step_mainwindow(self):
+        self.wait_confirm('GOBACK')
         # explain the concept of the clubhouse
         self.wait_confirm('EXPLAIN_MAIN1')
         self.wait_confirm('EXPLAIN_MAIN2')
@@ -61,13 +48,6 @@ class Meet(Quest):
             for msgid in ['CHANGE_NAME1', 'CHANGE_NAME2', 'CHANGE_NAME3']:
                 self.wait_confirm(msgid)
 
-        self.wait_confirm('END1')
-        self.wait_confirm('END2')
-        self.show_message('END3', choices=[('Got it!', self.step_end)])
-        return self.step_end
-
-    def step_end(self):
-        self.complete = True
-        self.available = False
-        Sound.play('quests/quest-complete')
-        self.stop()
+        for msgid in ['END1', 'END2', 'END3']:
+            self.wait_confirm(msgid)
+        return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/quickstart.py
+++ b/eosclubhouse/quests/hack2/quickstart.py
@@ -1,12 +1,17 @@
 from eosclubhouse.libquest import Quest
-from eosclubhouse.system import Sound
 
 
 class Quickstart(Quest):
 
-    __quest_name__ = 'Tutorial - The Clubhouse'
+    __quest_name__ = 'Tutorial - The Clubhouse - Quickstart'
     __tags__ = ['mission:ada']
-    __mission_order__ = 10
+    __auto_offer_info__ = {'confirm_before': False, 'start_after': 3}
+    __available_after_completing_quests__ = ['FirstContact']
+
+    def setup(self):
+        self.auto_offer = True
+        # Hide quest in UI
+        self.skippable = True
 
     def step_begin(self):
         self.wait_confirm('WELCOME1')
@@ -23,10 +28,4 @@ class Quickstart(Quest):
                 self.wait_confirm(msgid)
 
         self.wait_confirm('END1')
-        self.show_message('END2', choices=[('Got it!', self.step_end)])
-
-    def step_end(self):
-        self.complete = True
-        self.available = False
-        Sound.play('quests/quest-complete')
-        self.stop()
+        self.show_message('END2', choices=[('Got it!', self.step_complete_and_stop)])


### PR DESCRIPTION
Users are having trouble getting through the longer intro quest, so we'll make that optional and set the quickstart as the initial quest. 

https://phabricator.endlessm.com/T27928