### PR TITLE
clubhouse, libquest: Auto-offer quests when the app is displayed

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2327,14 +2327,12 @@ class ClubhouseApplication(Gtk.Application):
 
     def _run_episode_autorun_quest_if_needed(self):
         autorun_quest = libquest.Registry.get_autorun_quest()
-        if autorun_quest is None:
-            return
-
-        quest = libquest.Registry.get_quest_by_name(autorun_quest)
-        if not quest.complete:
+        if autorun_quest is not None:
             # Run the quest in the app's main instance
             self.activate_action('run-quest', GLib.Variant('(sb)', (autorun_quest, True)))
             return True
+
+        libquest.Registry.try_offer_quest()
 
         return False
 


### PR DESCRIPTION
This changes the behavior of auto-offering quests to:
- Auto-offered quests are tried when the Clubhouse window is displayed,
  right after trying the episode autorun quest.

- Auto-offered quests aren't tried again after cancelling them.

Changes needed:

- More methods moved to the Registry
- Some autorun logic moved from clubhouse module to libquest

https://phabricator.endlessm.com/T27850