### PR TITLE
libquest: Record quets id in QUEST_EVENT

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -806,14 +806,14 @@ class _Quest(GObject.GObject):
         pathways = [i.get_name() for i in self.get_pathways()]
         recorder = EosMetrics.EventRecorder.get_default()
         key = GLib.Variant('s', self.get_name())
-        payload = GLib.Variant('(bas)', (self.complete, pathways))
+        payload = GLib.Variant('(bsas)', (self.complete, self.get_id(), pathways))
         recorder.record_start(QUEST_EVENT, key, payload)
 
     def _stop_record_metrics(self):
         pathways = [i.get_name() for i in self.get_pathways()]
         recorder = EosMetrics.EventRecorder.get_default()
         key = GLib.Variant('s', self.get_name())
-        payload = GLib.Variant('(bas)', (self.complete, pathways))
+        payload = GLib.Variant('(bsas)', (self.complete, self.get_id(), pathways))
         recorder.record_stop(QUEST_EVENT, key, payload)
 
     def run(self, on_quest_finished):


### PR DESCRIPTION
The key of the sequence event is not stored in the metrics database, so
we should add the quest name to the payload if we want to be able to
query using quest name.

https://phabricator.endlessm.com/T28004