### PR TITLE
system: Don't override hack bg setting on first disable

### DIFF
--- a/eosclubhouse/quests/hack2/firstcontact.py
+++ b/eosclubhouse/quests/hack2/firstcontact.py
@@ -36,12 +36,7 @@ class FirstContact(Quest):
         return self._app.get_js_property('mode', default_value=0) >= 4
 
     def step_begin(self):
-        Desktop.set_hack_mode(True)
-        # While in Hack mode, because the FlipToHack button is needed, we still
-        # want to show the old background and the normal cursor.
-        Desktop.set_hack_background(False)
-        Desktop.set_hack_cursor(False)
-
+        Desktop.set_hack_mode(True, avoid_signal=True)
         self._app.launch()
 
         # Avoid spinning cursor.
@@ -118,6 +113,8 @@ class FirstContact(Quest):
     def step_show_clubhouse(self):
         self.pause(3)
 
+        # hack mode to true to emit the signal and ensure that the clubhouse is ON
+        Desktop.set_hack_mode(True)
         # show the clubhouse after the first contact quest
         clubhouse_state = ClubhouseState()
         clubhouse_state.window_is_visible = True
@@ -129,5 +126,5 @@ class FirstContact(Quest):
         self.stop()
 
     def step_abort(self):
-        Desktop.set_hack_mode(False)
+        Desktop.set_hack_mode(False, avoid_signal=True)
         super().step_abort()


### PR DESCRIPTION
There's a race condition with the first contact quest. The hack mode is
enabled and that emits a signal that changes the background.

But the first contact quest sets the background to the default one until
the quest is finished, so if the call from the quest is done before the
signal callback, the background setting is set to the current background
and when this method is called again, the background will not change
because the hack setting has the same background that we've right now.

This patch adds a new param to the set_hack_mode to block the signal
handler to be called. It's also needed to call to the set_hack_mode when
the first quest finish to ensure that all the signals are emited at the
end and we've the clubhouse ON with the correct animations.

https://phabricator.endlessm.com/T28046