### PR TITLE
libquest: Update confirm label to match the shell change

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -256,8 +256,10 @@ class Message(Gtk.Overlay):
 
         # Backward compatibility.
         # @todo: Remove when quests implement the new :icon:icon-name: format.
-        if label == '>':
+        if label == '❯':
             label = ':icon:next:'
+        elif label == '❮':
+            label = ':icon:previous:'
         elif label == '👍':
             label = ':icon:thumbsup:'
         elif label == '👎':

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1621,7 +1621,7 @@ class Quest(_Quest):
         :param bool use_confirm: True to add a confirmation button. See
             :meth:`show_confirm_message()` to do it automatically.
 
-        :param str confirm_label: Change the label of the confirm button. By default it's '>'.
+        :param str confirm_label: Change the label of the confirm button. By default it's '❯'.
 
         '''
         if message_id is not None:
@@ -1656,7 +1656,7 @@ class Quest(_Quest):
                                 in options['choices']]
 
         if options.get('use_confirm'):
-            confirm_label = options.get('confirm_label', '>')
+            confirm_label = options.get('confirm_label', '❯')
             possible_answers = [(confirm_label, self._confirm_step)] + possible_answers
 
         sfx_sound = options.get('sfx_sound')


### PR DESCRIPTION
Now we use a unicode next-arrow character, instead of a more-than
character.

https://phabricator.endlessm.com/T27845