### PR TITLE
clubhouse: save FirstContact complete status on migration

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2868,6 +2868,7 @@ class ClubhouseApplication(Gtk.Application):
         # Mark first contact quest (HackUnlock) as done
         quest = libquest.Registry.get_quest_by_name('FirstContact')
         quest.complete = True
+        quest.save_conf()
 
         # Unlock all hack1 lockscreens as part of the migration quest
         OldGameStateService().unlock_lockscreens()


### PR DESCRIPTION
We need to call directly to save_conf to make the complete status of the
FirstContact quest permanent and disable this quest in future clubhouse
runs.

https://phabricator.endlessm.com/T28356