### PR TITLE
data: remove NoDisplay from desktop file

### DIFF
--- a/data/com.hack_computer.Clubhouse.desktop
+++ b/data/com.hack_computer.Clubhouse.desktop
@@ -7,5 +7,4 @@ Icon=com.hack_computer.Clubhouse
 Exec=eos-clubhouse
 Terminal=false
 StartupNotify=true
-NoDisplay=true
 X-Endless-HackShader=true


### PR DESCRIPTION
The NoDisplay is not needed anymore, the clubhouse is not a side
component anymore.

https://phabricator.endlessm.com/T28374