### PR TITLE
clubhouse: Do not play ambient sound on hack mode on but no window

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2179,7 +2179,8 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
 
         if hack_mode_enabled:
             ctx.remove_class('off')
-            self.play_ambient_sound()
+            if self.props.visible:
+                self.play_ambient_sound()
         else:
             ctx.add_class('off')
             self.clubhouse.stop_quest()


### PR DESCRIPTION
It prevents the migration quest to play the ambient sound when
there is no a open window for the Clubhouse

https://phabricator.endlessm.com/T28383