### PR TITLE
quests: Add FableMaker to Web Pathway

### DIFF
--- a/eosclubhouse/quests/hack2/t2webfablemaker.py
+++ b/eosclubhouse/quests/hack2/t2webfablemaker.py
@@ -1,0 +1,26 @@
+from eosclubhouse.libquest import Quest
+from eosclubhouse.system import App
+
+
+class T2WebFableMaker(Quest):
+
+    APP_NAME = 'com.endlessnetwork.fablemaker'
+
+    __tags__ = ['pathway:web', 'difficulty:easy', 'skillset:LaunchQuests']
+    __pathway_order__ = 150
+
+    def setup(self):
+        self._app = App(self.APP_NAME)
+
+    def step_begin(self):
+        if not self._app.is_installed():
+            self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
+            return self.step_abort
+        else:
+            self.wait_confirm('GREET1')
+            self.wait_confirm('GREET2', confirm_label='Nice!')
+            return self.step_launch
+
+    def step_launch(self):
+        self._app.launch()
+        return self.step_complete_and_stop


### PR DESCRIPTION
Note, this app does not respect the always-on-top-ness of the Clubhouse, so it can potentially obscure badge popups on launch.

https://phabricator.endlessm.com/T28292