### PR TITLE
katamari: add flatpak version requirement

### DIFF
--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -47,7 +47,8 @@
         "--talk-name=ca.desrt.dconf",
         "--talk-name=com.endlessm.Libanimation",
         "--talk-name=org.freedesktop.Flatpak",
-        "--talk-name=org.gtk.Notifications"
+        "--talk-name=org.gtk.Notifications",
+        "--require-version=1.5.0"
     ],
 
     "modules": [


### PR DESCRIPTION
This will prevent the app from being installedon older systems through the app store as it
requires the latest Fltapak version to be present on the system.

https://phabricator.endlessm.com/T28464