### PR TITLE
clubhouse: Force hack background in hack activation

### DIFF
--- a/data/com.hack_computer.clubhouse.gschema.xml.in
+++ b/data/com.hack_computer.clubhouse.gschema.xml.in
@@ -2,11 +2,6 @@
 <schemalist>
   <schema id="com.hack_computer.clubhouse" path="/com/hack_computer/clubhouse/"
           gettext-domain="@GETTEXT_PACKAGE@">
-    <key type="s" name="hack-mode-enabled-picture-uri">
-      <default>''</default>
-      <summary>Hack mode desktop background.</summary>
-      <description>The desktop background to use in the Hack experience.</description>
-    </key>
     <key type="s" name="hack-mode-disabled-picture-uri">
       <default>''</default>
       <summary>Non-Hack mode desktop background.</summary>

--- a/data/tools/eos-hack-reset-clubhouse
+++ b/data/tools/eos-hack-reset-clubhouse
@@ -21,7 +21,6 @@ gsettings reset org.gnome.desktop.interface cursor-theme
 
 echo "Resetting the desktop background"
 gsettings reset org.gnome.desktop.background picture-uri
-gsettings reset com.hack_computer.clubhouse hack-mode-enabled-picture-uri
 gsettings reset com.hack_computer.clubhouse hack-mode-disabled-picture-uri
 
 echo "Resetting wobbly windows"

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -297,32 +297,29 @@ class Desktop:
 
     @classmethod
     def set_hack_background(klass, enabled):
-        ''' This changes the background to the Hack one '''
+        ''' This changes the background to the Hack one
+
+        When enabling the background will be always set to the HACK_BACKGROUND.
+
+        When disabling the background will be reset to the previous one stored
+        or if the user changes the background we keep the user custom.
+        '''
 
         desktop = Gio.Settings('org.gnome.desktop.background')
         clubhouse = Gio.Settings('com.hack_computer.clubhouse')
 
         old_picture_uri = desktop.get_string('picture-uri')
-        if enabled:
-            new_picture_uri = \
-                clubhouse.get_string('hack-mode-enabled-picture-uri') or klass.HACK_BACKGROUND
-        else:
+        # Enabling and the background is not the hack background yet
+        if enabled and old_picture_uri != klass.HACK_BACKGROUND:
+            desktop.set_string('picture-uri', klass.HACK_BACKGROUND)
+            clubhouse.set_string('hack-mode-disabled-picture-uri', old_picture_uri)
+        # Disabling hack and the background has not been changed
+        elif not enabled and old_picture_uri == klass.HACK_BACKGROUND:
             new_picture_uri = clubhouse.get_string('hack-mode-disabled-picture-uri')
-
-        # does nothing if the background shouldn't change
-        if new_picture_uri and new_picture_uri == old_picture_uri:
-            return
-
-        if new_picture_uri:
-            desktop.set_string('picture-uri', new_picture_uri)
-        else:
-            desktop.reset('picture-uri')
-
-        if old_picture_uri:
-            if enabled:
-                clubhouse.set_string('hack-mode-disabled-picture-uri', old_picture_uri)
+            if new_picture_uri:
+                desktop.set_string('picture-uri', new_picture_uri)
             else:
-                clubhouse.set_string('hack-mode-enabled-picture-uri', old_picture_uri)
+                desktop.reset('picture-uri')
 
     @classmethod
     def ensure_hack_cursor_is_present(klass):


### PR DESCRIPTION
This patch removes the hack-mode-enabled-picture-uri setting and set the
hack background always the hack mode is enabled.

The custom user background will be stored and set back when the hack
mode is disabled.

If the user changes the background during hack mode and then disables
the hack mode, the custom user background will be keep. But if user
enables the hack mode again, the hack background will be set.

https://phabricator.endlessm.com/T28472