### PR TITLE
quests, hack2, T2: start app directly and then instruct

### DIFF
--- a/eosclubhouse/quests/hack2/t2aqueducts.py
+++ b/eosclubhouse/quests/hack2/t2aqueducts.py
@@ -17,10 +17,10 @@ class T2Aqueducts(Quest):
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
         else:
-            self.wait_confirm('GREET1')
-            self.wait_confirm('GREET2', confirm_label='Cool!')
-            return self.step_launch
+            self._app.launch()
+            return self.step_instruct
 
-    def step_launch(self):
-        self._app.launch()
+    def step_instruct(self):
+        self.wait_confirm('GREET1')
+        self.wait_confirm('GREET2', confirm_label='Cool!')
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2intro.py
+++ b/eosclubhouse/quests/hack2/t2intro.py
@@ -34,11 +34,11 @@ class T2Intro(Quest):
         return self.step_normalrun
 
     def step_normalrun(self):
+        self._app.launch()
+        return self.step_instruct
+
+    def step_instruct(self):
         self.wait_confirm('GREET1')
         self.wait_confirm('GREET2', confirm_label='Will do!')
-        return self.step_launch
-
-    def step_launch(self):
         self.wait_confirm('BYE')
-        self._app.launch()
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2missile.py
+++ b/eosclubhouse/quests/hack2/t2missile.py
@@ -17,10 +17,10 @@ class T2Missile(Quest):
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
         else:
-            self.wait_confirm('GREET1')
-            self.wait_confirm('GREET2', confirm_label="I'll remember that...")
-            return self.step_launch
+            self._app.launch()
+            return self.step_instruct
 
-    def step_launch(self):
-        self._app.launch()
+    def step_instruct(self):
+        self.wait_confirm('GREET1')
+        self.wait_confirm('GREET2', confirm_label="I'll remember that...")
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2passage.py
+++ b/eosclubhouse/quests/hack2/t2passage.py
@@ -17,10 +17,10 @@ class T2Passage(Quest):
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
         else:
-            self.wait_confirm('GREET1')
-            self.wait_confirm('GREET2', confirm_label="We'll see!")
-            return self.step_launch
+            self._app.launch()
+            return self.step_instruct
 
-    def step_launch(self):
-        self._app.launch()
+    def step_instruct(self):
+        self.wait_confirm('GREET1')
+        self.wait_confirm('GREET2', confirm_label="We'll see!")
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2tank.py
+++ b/eosclubhouse/quests/hack2/t2tank.py
@@ -17,10 +17,10 @@ class T2Tank(Quest):
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
         else:
-            self.wait_confirm('GREET1')
-            self.wait_confirm('GREET2', confirm_label='Smart!')
-            return self.step_launch
+            self._app.launch()
+            return self.step_instruct
 
-    def step_launch(self):
-        self._app.launch()
+    def step_instruct(self):
+        self.wait_confirm('GREET1')
+        self.wait_confirm('GREET2', confirm_label='Smart!')
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2teddy.py
+++ b/eosclubhouse/quests/hack2/t2teddy.py
@@ -17,10 +17,10 @@ class T2Teddy(Quest):
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
         else:
-            self.wait_confirm('GREET1')
-            self.wait_confirm('GREET2', confirm_label='Definitely!')
-            return self.step_launch
+            self._app.launch()
+            return self.step_instruct
 
-    def step_launch(self):
-        self._app.launch()
+    def step_instruct(self):
+        self.wait_confirm('GREET1')
+        self.wait_confirm('GREET2', confirm_label='Definitely!')
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2whitehouse.py
+++ b/eosclubhouse/quests/hack2/t2whitehouse.py
@@ -17,10 +17,10 @@ class T2Whitehouse(Quest):
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
         else:
-            self.wait_confirm('GREET1')
-            self.wait_confirm('GREET2', confirm_label='Sounds fun!')
-            return self.step_launch
+            self._app.launch()
+            return self.step_instruct
 
-    def step_launch(self):
-        self._app.launch()
+    def step_instruct(self):
+        self.wait_confirm('GREET1')
+        self.wait_confirm('GREET2', confirm_label='Sounds fun!')
         return self.step_complete_and_stop


### PR DESCRIPTION
When a user clicks on the card and the quest is laucnhed
the app is started right away and then the instructions
follow.

This will help the user making that context switch to the
new app and also prevents from badges on the cards and
achievement badges being given right away as those are
granted and updated at the end of the quest.

https://phabricator.endlessm.com/T28379