### PR TITLE
katamari: skip .flatpak-builder folder

### DIFF
--- a/katamari/tools/_common.py
+++ b/katamari/tools/_common.py
@@ -142,6 +142,7 @@ def _get_dir_source(directory):
     return {
         'type': 'dir',
         'path': directory,
+        'skip': ['.flatpak-builder'],
     }
 
 


### PR DESCRIPTION
Building with the katamari tool gets the clubhouse directory as source
for the clubhouse, but if you build inside the clubhouse folder, the
.flatpak-builder/build will contain the whole clubhouse folder. To avoid
recoursion copy inside this subdirectory, this should be ignored.