### PR TITLE
clubhouse: unlock System app for Hack 1 users during migration

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2906,6 +2906,14 @@ class ClubhouseApplication(Gtk.Application):
             quest.save_conf()
 
         OldGameStateService().migrate()
+        gss = GameStateService()
+        keys = [
+            'lock.OperatingSystemApp.1',
+            'lock.OperatingSystemApp.2',
+            'lock.OperatingSystemApp.3'
+        ]
+        for key in keys:
+            gss.set_async(key, {'locked': False})
 
         # This write the local flatpak override for old and new hack apps
         Desktop.set_hack_mode(True)


### PR DESCRIPTION
The old System app has been replaced under the hack_computer namespace. We agreed on granting the Hack 1 users all of the hacking affordences for Hack 1 toy apps.

We only want to grant this for Hack 1 users. Eben though the "system tour" quest currently unlocks the toolbox during the quest we might want to change this in the near future.

https://phabricator.endlessm.com/T28554