### PR TITLE
libquest: Store all quest conf as a dict

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1974,9 +1974,8 @@ class Quest(_Quest):
 
         '''
         conf_key = self._get_conf_key()
-        for key, value in self.conf.items():
-            variant = convert_variant_arg({key: value})
-            self.gss.set_async(conf_key, variant)
+        variant = convert_variant_arg(self.conf)
+        self.gss.set_async(conf_key, variant)
 
         if self.complete:
             for item_id, extra_info in self.__items_on_completion__.items():


### PR DESCRIPTION
All conf uses the same conf_key so when storing in the gss each set
overrides the previous state, so only the last conf was really stored.

This patch changes the save_conf to store the whole quest conf dict.

https://phabricator.endlessm.com/T28726