### PR TITLE
utils: Don't insert hyphens in some shell dialogue's text

### DIFF
--- a/eosclubhouse/utils.py
+++ b/eosclubhouse/utils.py
@@ -325,21 +325,55 @@ class NewsFeedDB(_ListFromCSV):
 
 class SimpleMarkupParser:
 
-    _convertions = [
-        [re.compile(r'<', re.S), r'&lt;'],
-        [re.compile(r'>', re.S), r'&gt;'],
-        [re.compile(r'(\*)(?=\S)(.+?)(?<=\S)\1', re.S), r'<b>\2</b>'],  # bold
-        [re.compile(r'(_)(?=\S)(.+?)(?<=\S)\1', re.S), r'<i>\2</i>'],  # italics
-        [re.compile(r'(~)(?=\S)(.+?)(?<=\S)\1', re.S), r'<s>\2</s>'],  # strikethrough
-        [re.compile(r'(`)(?=\S)(.+?)(?<=\S)\1', re.S),  # inline code
-         r'<tt><span foreground="#287A8C" background="#FFFFFF">\2</span></tt>'],
-    ]
+    DEFAULT_TAGS = {
+        'bold_start': '<b>',
+        'bold_end': '</b>',
+        'italics_start': '<i>',
+        'italics_end': '</i>',
+        'strikethrough_start': '<s>',
+        'strikethrough_end': '</s>',
+        'inlinecode_start': ('<tt><span insert_hyphens="false" '
+                             'foreground="#287A8C" background="#FFFFFF">'),
+        'inlinecode_end': '</span></tt>',
+        'url_start': '<u><span insert_hyphens="false" foreground="#3584E4">',
+        'url_end': '</span></u>',
+    }
+    _convertions = None
+    _instance = None
+
+    def __init__(self, custom_tags=None):
+        tags = self.DEFAULT_TAGS.copy()
+        if isinstance(custom_tags, dict):
+            tags.update(custom_tags)
+
+        self._convertions = [
+            [re.compile(r'<', re.S), r'&lt;'],
+            [re.compile(r'>', re.S), r'&gt;'],
+            [re.compile(
+                # From http://www.noah.org/wiki/RegEx_Python#URL_regex_pattern
+                (r'(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|'
+                 r'(?:%[0-9a-fA-F][0-9a-fA-F]))+)'), re.S),
+             f'{tags["url_start"]}\\1{tags["url_end"]}'],
+            [re.compile(r'(\*)(?=\S)(.+?)(?<=\S)\1', re.S),
+             f'{tags["bold_start"]}\\2{tags["bold_end"]}'],
+            [re.compile(r'(_)(?=\S)(.+?)(?<=\S)\1', re.S),
+             f'{tags["italics_start"]}\\2{tags["italics_end"]}'],
+            [re.compile(r'(~)(?=\S)(.+?)(?<=\S)\1', re.S),
+             f'{tags["strikethrough_start"]}\\2{tags["strikethrough_end"]}'],
+            [re.compile(r'(`)(?=\S)(.+?)(?<=\S)\1', re.S),
+             f'{tags["inlinecode_start"]}\\2{tags["inlinecode_end"]}'],
+        ]
+
+    def _do_parse(self, text):
+        for regex, replacement in self._convertions:
+            text = regex.sub(replacement, text)
+        return text
 
     @classmethod
     def parse(class_, text):
-        for regex, replacement in class_._convertions:
-            text = regex.sub(replacement, text)
-        return text
+        if class_._instance is None:
+            class_._instance = class_()
+        return class_._instance._do_parse(text)
 
 
 class _ClubhouseStateImpl(GObject.GObject):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import datetime
 import unittest
 
-from eosclubhouse.utils import convert_variant_arg
+from eosclubhouse.utils import convert_variant_arg, SimpleMarkupParser
 
 
 class TestVariantConversion(unittest.TestCase):
@@ -14,3 +14,39 @@ class TestVariantConversion(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             convert_variant_arg({'no_serializable': datetime.datetime.now()})
+
+
+class TestMarkup(unittest.TestCase):
+
+    def test_can_foo(self):
+        """Tests that we can FOO."""
+
+        # We setup custom tags to simplify the checks:
+        custom_tags = {
+            'inlinecode_start': '<tt><span size="small">',
+            'inlinecode_end': '</span></tt>',
+            'url_start': '<u><span color="blue">',
+            'url_end': '</span></u>',
+        }
+        parser = SimpleMarkupParser(custom_tags)
+
+        values_to_test = [
+            ('We have *bold*, _italics_ and `code`.',
+             'We have <b>bold</b>, <i>italics</i> and <tt><span size="small">code</span></tt>.'),
+            ('*I am _very_ excited* about this quest!',
+             '<b>I am <i>very</i> excited</b> about this quest!'),
+            ('I ~despise~ am not a fan of soup.',
+             'I <s>despise</s> am not a fan of soup.'),
+            ('Try setting `gravity = 0` in the code.',
+             'Try setting <tt><span size="small">gravity = 0</span></tt> in the code.'),
+            ('Checkout this site! https://www.w3.org/2000/svg',
+             'Checkout this site! <u><span color="blue">https://www.w3.org/2000/svg</span></u>'),
+            ('Mixing `code and *bold*` allowed',
+             'Mixing <tt><span size="small">code and <b>bold</b></span></tt> allowed'),
+            ('URL in code `https://www.hack-computer.com/` allowed',
+             ('URL in code <tt><span size="small"><u><span color="blue">'
+              'https://www.hack-computer.com/</span></u></span></tt> allowed')),
+        ]
+
+        for in_, out in values_to_test:
+            self.assertEqual(out, parser._do_parse(in_))


### PR DESCRIPTION
Specifically, in URLs and inline code. For this, these texts are now
wrapped with a <span insert_hyphens="false"> to instruct Pango to
avoid hyphenation on them.

Also: Add back underline and color to matching URLs.

https://phabricator.endlessm.com/T28687