### PR TITLE
katamari: Set modules git branch to @BRANCH@ on template

### DIFF
--- a/katamari/tools/_common.py
+++ b/katamari/tools/_common.py
@@ -73,7 +73,7 @@ class Config:
         return method(key, self._defs[section][key])
 
     def get_default_branch(self):
-        return 'stable' if self.get('Common', 'stable') else 'master'
+        return 'eos3' if self.get('Common', 'stable') else 'master'
 
     def get_flatpak_branch(self):
         # First, check if there is an override in the advanced


### PR DESCRIPTION
To build the eos3 branch we should use the same branch for each module.
To do this we should use the template string @BRANCH@ for each module
when we generate the manifest template file.

https://phabricator.endlessm.com/T28948