### PR TITLE
katamari: Don't use pip to install dbusmock

### DIFF
--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -172,16 +172,37 @@
 
         /** eos-metrics needed by toolbox and not present in EOS **/
         {
-            "name": "dbusmock",
+            "name": "dbus-python",
             "buildsystem": "simple",
-            "build-options": {
-              "build-args": [
-                "--share=network"
-              ]
-            },
+            "ensure-writable": [
+                "easy-install.pth"
+            ],
             "build-commands": [
-                "pip3 install --prefix=/app python-dbusmock",
-                "pip3 install --prefix=/app dbus-python"
+                "pip3 install --no-index --find-links=\"file://$${PWD}\" --prefix=$${FLATPAK_DEST} dbus-python"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b6/85/7b46d31f15a970665533ad5956adee013f03f0ad4421c3c83304ae9c9906/dbus-python-1.2.12.tar.gz",
+                    "sha256": "cdd4de2c4f5e58f287b12013ed7b41dee81d503c8d0d2397c5bd2fb01badf260"
+                }
+            ]
+        },
+        {
+            "name": "python-dbusmock",
+            "buildsystem": "simple",
+            "ensure-writable": [
+                "easy-install.pth"
+            ],
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://$${PWD}\" --prefix=$${FLATPAK_DEST} python-dbusmock"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d3/61/dcc36e58577446c70ffa1cdca4c93dae5fd651c840eaf5717d98a4560aa7/python-dbusmock-0.18.3.tar.gz",
+                    "sha256": "994a178268b6d74aeb158c0f155cd141e9a0cfae14226a764cd022c4949fe242"
+                }
             ]
         },
         {


### PR DESCRIPTION
Use pip to install python dependencies requires network access during the build process.

https://phabricator.endlessm.com/T28999