### PR TITLE
data, newsfeed: make sure release notes stay top for three days

### DIFF
--- a/data/newsfeed/newsfeed.csv
+++ b/data/newsfeed/newsfeed.csv
@@ -105,8 +105,8 @@ We can't wait to see what you'll do next! "
 2019-12-24,Estelle,,,@Saniel Haha!
 2019-12-24,Faber,,,@Saniel XD
 2019-12-24,Ada,,,"@Saniel Now there’s a true Christmas gift – a joke from Saniel Rowe. Happy Holidays, everyone!"
-2019-12-21,Endless,lego2.jpg,https://www.leocad.org/,Are you a Lego maniac? Create your own Lego design and built it in real life with this design application. Tag #MadeToHack on your designs and we'll like our favs. 
-2019-12-20,Endless,kedar.jpg,http://bit.ly/2Yr0O49,"At the age of 7, Kedar Narayan is solving real-world problems with code. Check out his Ted talk as he explains how he invented Storibot, a code-based board game for the blind."
+2019-12-23,Endless,lego2.jpg,https://www.leocad.org/,Are you a Lego maniac? Create your own Lego design and built it in real life with this design application. Tag #MadeToHack on your designs and we'll like our favs. 
+2019-12-22,Endless,kedar.jpg,http://bit.ly/2Yr0O49,"At the age of 7, Kedar Narayan is solving real-world problems with code. Check out his Ted talk as he explains how he invented Storibot, a code-based board game for the blind."
 2019-12-19,Endless,hack-release.jpg,,"<b>Hack December Release</b>
 Today, we proudly announce Hack's December Release! We hope you like it - let us know what you think on social media with #MadeToHack!
 


### PR DESCRIPTION
Moving the next posts two days out in order to have the release notes stay at the top
for two more days.