### PR TITLE
quests: Fix stop of Sidetrack1 and System_Tour

### DIFF
--- a/eosclubhouse/quests/hack2/sidetrack1.py
+++ b/eosclubhouse/quests/hack2/sidetrack1.py
@@ -1,5 +1,4 @@
 from eosclubhouse.libquest import Quest
-from eosclubhouse.system import Sound
 from eosclubhouse import logger
 
 
@@ -163,5 +162,4 @@ class Sidetrack1(Quest):
 
     def step_success(self):
         self.wait_confirm('SUCCESS')
-        Sound.play('quests/quest-complete')
-        return self.step_complete_and_stop(available=False)
+        return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/system_tour.py
+++ b/eosclubhouse/quests/hack2/system_tour.py
@@ -27,4 +27,4 @@ class System_Tour(Quest):
         self.wait_confirm('STUFFTODO')
         self.wait_for_app_js_props_changed(props=['flipped'])
         self.wait_confirm('FLIPPEDSTUFF')
-        return self.step_complete_and_stop(available=False)
+        return self.step_complete_and_stop


### PR DESCRIPTION
Quests should not set themselves as unavailable after complete.

Also in Sidetrack1, the sound is played twice, because the
complete_and_stop step already plays it.

https://phabricator.endlessm.com/T29033