### PR TITLE
quests: Improve messages in T2 games

### DIFF
--- a/eosclubhouse/quests/hack2/t2aqueducts.py
+++ b/eosclubhouse/quests/hack2/t2aqueducts.py
@@ -11,11 +11,15 @@ class T2Aqueducts(Quest):
         if not self.app.is_installed():
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
-        else:
-            self.app.launch()
-            return self.step_instruct
+        return self.step_instruct
 
     def step_instruct(self):
         self.wait_confirm('GREET1')
         self.wait_confirm('GREET2', confirm_label='Cool!')
+        return self.step_launch
+
+    def step_launch(self):
+        self.app.launch()
+        self.wait_for_app_in_foreground()
+        self.wait_for_app_in_foreground(in_foreground=False)
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2frogsquash.py
+++ b/eosclubhouse/quests/hack2/t2frogsquash.py
@@ -29,11 +29,13 @@ class T2FrogSquash(Quest):
         return self.step_normalrun
 
     def step_normalrun(self):
-        self.app.launch()
-        return self.step_instruct
-
-    def step_instruct(self):
         self.wait_confirm('GREET1')
         self.wait_confirm('GREET2', confirm_label='Will do!')
         self.wait_confirm('BYE')
+        return self.step_launch
+
+    def step_launch(self):
+        self.app.launch()
+        self.wait_for_app_in_foreground()
+        self.wait_for_app_in_foreground(in_foreground=False)
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2passage.py
+++ b/eosclubhouse/quests/hack2/t2passage.py
@@ -11,11 +11,15 @@ class T2Passage(Quest):
         if not self.app.is_installed():
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
-        else:
-            self.app.launch()
-            return self.step_instruct
+        return self.step_instruct
 
     def step_instruct(self):
         self.wait_confirm('GREET1')
         self.wait_confirm('GREET2', confirm_label="We'll see!")
+        return self.step_launch
+
+    def step_launch(self):
+        self.app.launch()
+        self.wait_for_app_in_foreground()
+        self.wait_for_app_in_foreground(in_foreground=False)
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2tank.py
+++ b/eosclubhouse/quests/hack2/t2tank.py
@@ -11,11 +11,15 @@ class T2Tank(Quest):
         if not self.app.is_installed():
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
-        else:
-            self.app.launch()
-            return self.step_instruct
+        return self.step_instruct
 
     def step_instruct(self):
         self.wait_confirm('GREET1')
         self.wait_confirm('GREET2', confirm_label='Smart!')
+        return self.step_launch
+
+    def step_launch(self):
+        self.app.launch()
+        self.wait_for_app_in_foreground()
+        self.wait_for_app_in_foreground(in_foreground=False)
         return self.step_complete_and_stop

--- a/eosclubhouse/quests/hack2/t2teddy.py
+++ b/eosclubhouse/quests/hack2/t2teddy.py
@@ -11,11 +11,15 @@ class T2Teddy(Quest):
         if not self.app.is_installed():
             self.wait_confirm('NOTINSTALLED', confirm_label='App Center, got it.')
             return self.step_abort
-        else:
-            self.app.launch()
-            return self.step_instruct
+        return self.step_instruct
 
     def step_instruct(self):
         self.wait_confirm('GREET1')
         self.wait_confirm('GREET2', confirm_label='Spooky!')
+        return self.step_launch
+
+    def step_launch(self):
+        self.app.launch()
+        self.wait_for_app_in_foreground()
+        self.wait_for_app_in_foreground(in_foreground=False)
         return self.step_complete_and_stop


### PR DESCRIPTION
Revert a6511c1 to give the instructions before the app launches,
because once the app goes fullscreen, the messages will be occluded by
the app. Also, wait until the app loses the foreground state before
completing the quest, to prevent giving the badge behind the
fullscreen app.

https://phabricator.endlessm.com/T28890