### PR TITLE
clubhouse: Update switch css on init

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -1219,6 +1219,7 @@ class ClubhouseViewMainLayer(Gtk.Fixed):
     def _on_lights_changed_cb(self, state, _param):
         if state.lights_on != self._hack_switch.get_active():
             self.set_switch_active(state.lights_on)
+        self._update_switch_css()
 
     def _on_hack_switch_highlighted_changed_cb(self, state, _param):
         ctx = self._hack_switch.get_style_context()


### PR DESCRIPTION
When init the clubhouse with the hack mode off the switch button text is
not synced and there's an inconsistence there showing the text ON and
the button in the OFF state.

This patch fixes the problem just updating the button css everytime the
lights changed, not only when the state is different.

https://phabricator.endlessm.com/T29076