### PR TITLE
katamari: Remove network requirement

### DIFF
--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -36,7 +36,6 @@
         "--own-name=com.hack_computer.HackSoundServer",
         "--own-name=com.hack_computer.HackToolbox",
         "--share=ipc",
-        "--share=network",
         "--socket=pulseaudio",
         "--socket=session-bus",
         "--socket=wayland",


### PR DESCRIPTION
It was added in katamari commit eebf4353 to show the News page for
ticket https://phabricator.endlessm.com/T27503 . But that was a
prototype. The current News page doesn't require Internet connection.

https://phabricator.endlessm.com/T29095