### PR TITLE
clubhouse: Add sort function in quest flow box

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -940,6 +940,8 @@ class CharacterView(Gtk.Grid):
 
         self._quests_handlers = []
 
+        self._list.set_sort_func(self._sort_func)
+
         self._clubhouse_state = ClubhouseState()
         self._clubhouse_state.connect('notify::nav-attract-state',
                                       self._on_clubhouse_nav_attract_state_changed_cb)
@@ -949,6 +951,9 @@ class CharacterView(Gtk.Grid):
                                  self.update_character_image(idle=True))
 
         self.message_box.show_all()
+
+    def _sort_func(self, row1, row2):
+        return row1.get_quest().get_pathway_order() - row2.get_quest().get_pathway_order()
 
     def update_character_image(self, idle=False):
         if self._character is None:

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1388,6 +1388,10 @@ class _Quest(GObject.GObject):
                 QuestStringCatalog().get_string(f'{self._qs_base_id}_{message_id}'))
 
     @classmethod
+    def get_pathway_order(class_):
+        return class_.__pathway_order__
+
+    @classmethod
     def is_narrative(class_):
         return class_.__is_narrative__
 
@@ -2288,7 +2292,7 @@ class QuestSet(GObject.GObject):
 
     def _sort_quests(self):
         def by_order(quest):
-            return quest.__pathway_order__
+            return quest.get_pathway_order()
 
         self._quest_objs.sort(key=by_order)
 


### PR DESCRIPTION
In specific, this commits prevents to add a quest at Sidetrack2 at
the end position when Sidetrack1 gets completed.

https://phabricator.endlessm.com/T29165