### PR TITLE
data, newsfeed: do not provide a link for Sidetrack 2

### DIFF
--- a/data/newsfeed/newsfeed.csv
+++ b/data/newsfeed/newsfeed.csv
@@ -13,8 +13,7 @@ Today, we proudly announce Hack's January Release! We hope you like it - let us 
 
 The following content has been added:
 
-<b>Sidetrack 2 - Flip To Hack </b>Riley continues presenting her game project, and introduces the ""Flip To Hack"" system that lets you delve into the code and change as the game runs! Debug that pesky broken instruction in Level 23, and push ahead into new territory!
-<a href='quest://Sidetrack2'>Play Now!</a>
+<b>Sidetrack 2 - Flip To Hack </b>Riley continues presenting her game project, and introduces the ""Flip To Hack"" system that lets you delve into the code and change as the game runs! Debug that pesky broken instruction in Level 23, and push ahead into new territory! This quest will become available in the <b>games pathway</b> when Sidetrack 1 is completed.
 
 <b>Make your own Happiness</b> Sometimes, doing something to help someone else can make you feel just fantastic. In this new activity, learn some strategies for making a positive impact on someone close to you.
 <a href='quest://MakerHappiness'>Play Now!</a>


### PR DESCRIPTION
The quest only becomes available after Sidetrack 1 is completed, so the player should not be able to start it from here.