### PR TITLE
tools: Use GNOME runtime 3.34 to setup the Python virtualenv

### DIFF
--- a/tools/setup-venv
+++ b/tools/setup-venv
@@ -16,7 +16,7 @@ source_dir="$(git rev-parse --show-toplevel)"
 # building locally) since it needs to be properly set up from within the sandbox.
 virtualenv_dir="${source_dir}/.python-virtual-env$FLATPAK_ID"
 
-runtime="org.gnome.Platform//3.32"
+runtime="org.gnome.Platform//3.34"
 flatpak_shell="flatpak run --filesystem=$source_dir --share=network --command=bash $runtime"
 
 # if this is being called while building flatpak, then we run the command directly, and do not


### PR DESCRIPTION
The Jenkins job is failing with: `error: app/org.gnome.Platform/x86_64/3.32 not installed`. Hopefully this fixes it. The full error is:
```
See <https://ci.endlessm-sf.com/job/nightly-clubhouse-string-integration/244/display/redirect?page=changes>

Changes:

[Manuel Quiñones] tools, data: Drop remaining rows when importing strings

[Fabian Orccon] libquest: Set default ABORT message

[Fabian Orccon] data: Update quests strings CSV

[lyman] Adding files for bootstrap2 quest

------------------------------------------
Started by timer
Running as SYSTEM
Building remotely on jenkins-builder1 (flatpak-builder-x86_64 flatpak-builder flatpak-builder-i386 x86-container-builders) in workspace <https://ci.endlessm-sf.com/job/nightly-clubhouse-string-integration/ws/>
[ssh-agent] Looking for ssh-agent implementation...
[ssh-agent]   Exec ssh-agent (binary ssh-agent on a remote machine)
$ ssh-agent
SSH_AUTH_SOCK=/tmp/ssh-klJTkfG1Wtnt/agent.16840
SSH_AGENT_PID=16842
[ssh-agent] Started.
Running ssh-add (command line suppressed)
Identity added: <https://ci.endlessm-sf.com/job/nightly-clubhouse-string-integration/ws/@tmp/private_key_16935742342161856886.key> (<https://ci.endlessm-sf.com/job/nightly-clubhouse-string-integration/ws/@tmp/private_key_16935742342161856886.key)>
[ssh-agent] Using credentials jenkins-github-rw (Github read/write access)
using credential fe45ca53-7c92-47db-b3b1-b8d0cc8507ed
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url git@github.com:endlessm/clubhouse.git # timeout=10
Fetching upstream changes from git@github.com:endlessm/clubhouse.git
 > git --version # timeout=10
using GIT_SSH to set credentials Github read/write access
 > git fetch --tags --force --progress git@github.com:endlessm/clubhouse.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse refs/remotes/origin/master^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/origin/master^{commit} # timeout=10
Checking out Revision 25f6fa9afb6694ce6e2ff660f6c0bc326e24f4dc (refs/remotes/origin/master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 25f6fa9afb6694ce6e2ff660f6c0bc326e24f4dc
Commit message: "Adding files for bootstrap2 quest"
 > git rev-list --no-walk 6c5b1599cada6d21f6d3c5e3818e54525d91606c # timeout=10
[nightly-clubhouse-string-integration] $ /bin/sh -xe /tmp/jenkins7119251732569562112.sh
+ ./tools/update-strings.sh --push
Already up to date.
HEAD is up to date.
~/workspace/nightly-clubhouse-string-integration ~/workspace/nightly-clubhouse-string-integration
Setting up virtual env <https://ci.endlessm-sf.com/job/nightly-clubhouse-string-integration/ws/.python-virtual-env>
error: app/org.gnome.Platform/x86_64/3.32 not installed
Upgrading pip
error: app/org.gnome.Platform/x86_64/3.32 not installed
Installing flake8
error: app/org.gnome.Platform/x86_64/3.32 not installed
Installing libsass
error: app/org.gnome.Platform/x86_64/3.32 not installed
Installing sphinx-autoapi
error: app/org.gnome.Platform/x86_64/3.32 not installed
error: app/org.gnome.Platform/x86_64/3.32 not installed
 [01;31mThere was an error compiling the CSS. Please fix the SASS file. [0m
HEAD detached at 25f6fa9a
nothing to commit, working tree clean
~/workspace/nightly-clubhouse-string-integration
Build step 'Execute shell' marked build as failure
$ ssh-agent -k
unset SSH_AUTH_SOCK;
unset SSH_AGENT_PID;
echo Agent pid 16842 killed;
[ssh-agent] Stopped.
```