### PR TITLE
tools: Simplify virtualenv usage

### DIFF
--- a/tools/setup-venv
+++ b/tools/setup-venv
@@ -16,32 +16,14 @@ source_dir="$(git rev-parse --show-toplevel)"
 # building locally) since it needs to be properly set up from within the sandbox.
 virtualenv_dir="${source_dir}/.python-virtual-env$FLATPAK_ID"
 
-runtime="org.gnome.Platform//3.34"
-flatpak_shell="flatpak run --filesystem=$source_dir --share=network --command=bash $runtime"
-
-# if this is being called while building flatpak, then we run the command directly, and do not
-# attempt to run another flatpak sandbox.
-if [ ! -z $FLATPAK_ID ]; then
-    flatpak_shell="bash"
-fi
-
 function run_in_python_venv {
-    return $($flatpak_shell <<EOF
-    source "$virtualenv_dir/bin/activate"
-    eval $@ >&2
-    ret=\$?
-    deactivate
-    exit \$ret
-EOF
-            )
+    PATH="$virtualenv_dir/bin:$PATH" "$@"
 }
 
 function setup_venv {
     if [ ! -f $virtualenv_dir/bin/flake8 ]; then
         echo "Setting up virtual env $virtualenv_dir"
-        $flatpak_shell <<EOF
-            python3 -mvenv "$virtualenv_dir"
-EOF
+        python3 -mvenv "$virtualenv_dir"
         echo "Upgrading pip"
 	run_in_python_venv pip install --upgrade pip
         echo "Installing flake8"


### PR DESCRIPTION
First, use the host's python3 to setup the virtualenv. Then, change
`run_in_python_venv` to simply call the program from the venv's `bin`
directory. Part of the virtualenv setup is that the shebang line on all
the scripts is adjusted so it uses the `python` in the virtualenv. That
means the whole `activate`/`deactivate` dance is unnecessary as long as
the tools you're calling are installed from `pip`.

https://phabricator.endlessm.com/T29301