### PR TITLE
quest, Sidetrack2: add detection for error fixed

### DIFF
--- a/data/quests_strings/sidetrack2.csv
+++ b/data/quests_strings/sidetrack2.csv
@@ -27,15 +27,16 @@ SIDETRACK2_UNLOCK3,"I'm interested to see what the <b>Toolbox</b> looks like, Ri
 SIDETRACK2_GIVE_KEY,"I do, right here. Here you go!",riley,,,
 SIDETRACK2_UNLOCK4,"Now, because you have the key, the lock should light up and make some sounds - that's telling you it's ready to be opened. Click on the lock to open it.
 ",riley,,,
-SIDETRACK2_TOOLBOX_INSTRUCTIONS,"Cool! Now you have access to the <b>Instructions</b> - Exactly the same as those icons you were dragging around on the front side of Sidetrack, but here they're written as actual code!
+SIDETRACK2_LEVEL_23_TOOLBOX,"Cool! Now you have access to the <b>Instructions</b> - Exactly the same as those icons you were dragging around on the front side of Sidetrack, but here they're written as actual code!
 
 Check it out, one of the <b>instructions</b> is highlighted red, which means there's an error in the code. An error could be a lot of different things, but in this case it's pretty simple - If you're writing code, it has to be spelled and captialized <b>exactly</b> how the computer expects it to be. Anything else, it's an error!
 
 <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">jumpp</span></tt> isn't a correct <b>instruction</b>, and I think you know why! It's pretty clearly misspelled, so fix that, and then flip back to the front of Sidetrack.
 ",riley,,,
-SIDETRACK2_TOOLBOX_INSTRUCTIONS_HINT1,"Do you see the line in the code where it says <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">riley.jumpp();</span></tt>?  There's only 1 <b>p</b> in <b>jump</b>!",saniel,,,
-SIDETRACK2_TOOLBOX_INSTRUCTIONS_HINT2,"Change that code to say <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">riley.jump()</span></tt>, then flip back to the front and press <b>Play</b>.",saniel,,,
-SIDETRACK2_PLAY_HINT,"OK, let's give it a shot!",riley,,,
+SIDETRACK2_LEVEL_23_TOOLBOX_HINT1,"Do you see the line in the code where it says <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">riley.jumpp();</span></tt>?  There's only 1 <b>p</b> in <b>jump</b>!",saniel,,,
+SIDETRACK2_LEVEL_23_TOOLBOX_HINT2,"Change that code to say <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">riley.jump()</span></tt>, then flip back to the front and press <b>Play</b>.",saniel,,,
+SIDETRACK2_LEVEL_23_FLIP_HINT,"Awesome, you fixed it. Now flip back to the front side of Sidetrack.",,,,
+SIDETRACK2_LEVEL_23_PLAY_HINT,"OK, let's give it a shot!",riley,,,
 SIDETRACK2_LEVEL_24,"Yow, looks like this level has 2 errors! We'll need to fix both if you want to get through.",faber,,,
 SIDETRACK2_LEVEL_24_HINT1,Let's get to the <b>Instructions</b> again by <b>flipping</b> the app!,riley,,,
 SIDETRACK2_LEVEL_24_TOOLBOX,I think I can see the problem here!,riley,,,
@@ -44,6 +45,8 @@ SIDETRACK2_LEVEL_24_TOOLBOX_HINT2,"Do you see where it says <tt><span insert_hyp
 SIDETRACK2_LEVEL_24_TOOLBOX_HINT3,"Oh, hey, I think I see another problem. Look at the capitalization in the code.
 
 Did you spot it? I think it should be <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">riley.jump()</span></tt>, not <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">riley.<b>J</b>ump()</span></tt> <b>=^.‿.^=</b>",faber,,,
+SIDETRACK2_LEVEL_24_FLIP_HINT,You are getting the hang of it! Now flip back to the front side of Sidetrack.,estelle,,,
+SIDETRACK2_LEVEL_24_PLAY_HINT,Let's give it a shot!,riley,,,
 SIDETRACK2_LEVEL_25,"Riley, did you remember to test your code? We've hit quite a lot of errors, so far.",estelle,,,
 SIDETRACK2_LEVEL_26,"I'm not so sure this is a mistake. Every instruction in this set is wrong! Statistically, the probability of that occurring is quite low.",ada,,,
 SIDETRACK2_LEVEL_26_HINT1,Let's get to the <b>Instructions</b> again by <b>flipping</b> the app!,riley,,,

--- a/eosclubhouse/quests/hack2/sidetrack2.py
+++ b/eosclubhouse/quests/hack2/sidetrack2.py
@@ -107,7 +107,7 @@ class Sidetrack2(Quest):
 
         while not self.is_panel_unlocked('lock.sidetrack.1') and not self.is_cancelled():
             self.connect_gss_changes().wait()
-        self.pause(4)
+        self.pause(12)
 
         return self.step_play_level, False
 
@@ -116,15 +116,28 @@ class Sidetrack2(Quest):
         current_level = int(self._app.get_js_property('currentLevel'))
         message_id = None
         if current_level == 23:
-            self.show_hints_message('TOOLBOX_INSTRUCTIONS')
+            self.show_hints_message('LEVEL_23_TOOLBOX')
+            self.wait_for_codeview_errors('instructions')
+            self.app.pulse_flip_to_hack_button(True)
+            self.show_message('LEVEL_23_FLIP_HINT')
             action = self.connect_app_js_props_changes(self._app, ['flipped'])
             self.wait_for_one([action])
-            self.show_message('PLAY_HINT')
+            self.app.pulse_flip_to_hack_button(False)
+            self.show_message('LEVEL_23_PLAY_HINT')
         elif current_level == 24:
             self.show_hints_message('LEVEL_24')
+            self.app.pulse_flip_to_hack_button(True)
             action = self.connect_app_js_props_changes(self._app, ['flipped'])
             self.wait_for_one([action])
+            self.app.pulse_flip_to_hack_button(False)
             self.show_hints_message('LEVEL_24_TOOLBOX')
+            self.wait_for_codeview_errors('instructions')
+            self.app.pulse_flip_to_hack_button(True)
+            self.show_message('LEVEL_24_FLIP_HINT')
+            action = self.connect_app_js_props_changes(self._app, ['flipped'])
+            self.wait_for_one([action])
+            self.app.pulse_flip_to_hack_button(False)
+            self.show_message('LEVEL_24_PLAY_HINT')
         elif current_level == 25:
             message_id = self._get_unconfirmed_message(['LEVEL_25'])
         elif current_level == 26:


### PR DESCRIPTION
To instruct the player step-by-step how to use Flip-To-Hack add detection when the error has been
fixed and ask the player to flip back. Pulsate the flip-button accordingly.

Do the same improvements to level 24.

Also make the pausing after unlocking greater so the player has time to enjoy the toolbox.

https://phabricator.endlessm.com/T29253