### PR TITLE
Quests, Inspector2: Added missing url for window launch on line 17

### DIFF
--- a/eosclubhouse/quests/hack2/inspector2.py
+++ b/eosclubhouse/quests/hack2/inspector2.py
@@ -14,7 +14,7 @@ class Inspector2(Quest):
         return self.step_launch
 
     def step_launch(self):
-        self.open_url_in_browser('about:blank')
+        self.open_url_in_browser('https://www.hack-computer.com/about')
         return self.step_main_loop
 
     def step_main_loop(self, message_index=0):


### PR DESCRIPTION
It is not a show stopper. Can be merged in the March release since the user can click the url in the dialogue.

https://phabricator.endlessm.com/T29417