### PR TITLE
libquest: Ignore insert_hyphens pango tag in narrative dialogues

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -749,6 +749,13 @@ class _Quest(GObject.GObject):
         else:
             message_info['parsed_text'] = message_info['txt']
 
+        # @todo: Remove this when updating to a runtime using Pango >= 1.44, because
+        # insert_hyphens is not supported in the current version of our runtime.
+        if self.is_narrative():
+            parsed_text = message_info['parsed_text']
+            message_info['parsed_text'] = parsed_text.replace('insert_hyphens="true"', '')
+            message_info['parsed_text'] = parsed_text.replace('insert_hyphens="false"', '')
+
         return message_info
 
     def _setup_labels(self):


### PR DESCRIPTION
Our runtime uses 1.42.3, but "insert_hyphens" had been added since
Pango 1.44 in 2e6f2eb8.

It only make sense to ignore "insert_hyphens" in narrative
dialogues because in the GNOME Shell we are using a newer version
of Pango, while using an older one for narrative dialogues.

https://phabricator.endlessm.com/T29415