### PR TITLE
lint: Fix lint fail in sidetrack2 and sidetrack3

### DIFF
--- a/eosclubhouse/quests/hack2/sidetrack2.py
+++ b/eosclubhouse/quests/hack2/sidetrack2.py
@@ -41,7 +41,7 @@ class Sidetrack2(Quest):
         # method in Quest
         current_level = int(self._app.get_js_property('currentLevel'))
         while current_level == 0:
-            logger.debug(f'Current level is 0, waiting for sidetrack to load data')
+            logger.debug('Current level is 0, waiting for sidetrack to load data')
             self.pause(1)
             current_level = self._app.get_js_property('currentLevel')
 

--- a/eosclubhouse/quests/hack2/sidetrack3.py
+++ b/eosclubhouse/quests/hack2/sidetrack3.py
@@ -40,7 +40,7 @@ class Sidetrack3(Quest):
         # method in Quest
         current_level = int(self._app.get_js_property('currentLevel'))
         while current_level == 0:
-            logger.debug(f'Current level is 0, waiting for sidetrack to load data')
+            logger.debug('Current level is 0, waiting for sidetrack to load data')
             self.pause(1)
             current_level = self._app.get_js_property('currentLevel')
 


### PR DESCRIPTION
- Error:
sidetrack2.py:44:26: F541 f-string is missing placeholders
sidetrack3.py:43:26: F541 f-string is missing placeholders
- Apparent Cause:
Strings require no substitutions, which raises a lint error
- Remedy:
Return strings to being normal double-quoted strings

No task, but I can add one if we really want. I needed to fix this before I could test the newsfeed update!
(also testing out an idea I had for describing fixes, let me know what you think)