### PR TITLE
Use onboarding dbus path instead of tour

### DIFF
--- a/eosclubhouse/tour.py
+++ b/eosclubhouse/tour.py
@@ -46,8 +46,8 @@ class TourServer(metaclass=tour_meta):
 
     _proxy = None
     _properties_proxy = None
-    _DBUS_PATH = '/com/endlessm/tour'
-    _DBUS_ID = 'com.endlessm.tour'
+    _DBUS_PATH = '/com/endlessm/onboarding'
+    _DBUS_ID = 'com.endlessm.onboarding'
     _CALL_TIMEOUT = 20_000
 
     @classmethod

--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -47,7 +47,7 @@
         "--talk-name=org.gtk.Notifications",
         "--talk-name=org.gnome.Shell",
         "--talk-name=com.hack_computer.hack",
-        "--talk-name=com.endlessm.tour",
+        "--talk-name=com.endlessm.onboarding",
         "--require-version=1.5.0"
     ],
 


### PR DESCRIPTION
The tour extension has been renamed to onboarding

https://phabricator.endlessm.com/T30237