### PR TITLE
libquest: set clubhouse notification on top of tour highlight

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -2184,7 +2184,9 @@ class Quest(_Quest):
         def _on_finished(ret):
             async_action.resolve(not ret)
 
+        Tour.cloneWindowRole = 'clubhouse-msg-notify'
         Tour._call_method(function, *args, callback=_on_finished)
+        Tour.cloneWindowRole = ''
         self._run_context.wait_for_action(async_action, timeout)
 
         return async_action

--- a/eosclubhouse/tour.py
+++ b/eosclubhouse/tour.py
@@ -41,6 +41,14 @@ class tour_meta(type):
     def skippable(cls, value):
         cls.set_prop('Skippable', value)
 
+    @property
+    def cloneWindowRole(cls):
+        return cls.get_prop('CloneWindowRole')
+
+    @cloneWindowRole.setter
+    def cloneWindowRole(cls, value):
+        cls.set_prop('CloneWindowRole', value)
+
 
 class TourServer(metaclass=tour_meta):
 


### PR DESCRIPTION
This depends on the onboarding extension PR: https://github.com/endlessm/eos-onboarding-extension/pull/3 that adds a new property.

https://phabricator.endlessm.com/T30672