### PR TITLE
system: Add Hostname.is_laptop API

### DIFF
--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -1012,6 +1012,45 @@ class UserAccount(GObject.GObject):
         self._proxy.SetRealName(name)
 
 
+class Hostname(GObject.GObject):
+
+    _INTERFACE_NAME = 'org.freedesktop.hostname1'
+    _INTERFACE_PATH = '/org/freedesktop/hostname1'
+
+    __gsignals__ = {
+        'changed': (
+            GObject.SignalFlags.RUN_FIRST, None, ()
+        ),
+    }
+
+    _proxy = None
+    _props = None
+
+    @classmethod
+    def proxy(klass):
+        if klass._proxy is None:
+            system_bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+            klass._proxy = Gio.DBusProxy.new_sync(system_bus, 0, None,
+                                                  klass._INTERFACE_NAME,
+                                                  klass._INTERFACE_PATH,
+                                                  klass._INTERFACE_NAME,
+                                                  None)
+        return klass._proxy
+
+    @classmethod
+    def get_chassis(klass):
+        prop = klass.proxy().get_cached_property('Chassis')
+        return prop.unpack()
+
+    @classmethod
+    def is_laptop(klass):
+        return klass.get_chassis() == 'laptop'
+
+    @classmethod
+    def is_desktop(klass):
+        return not klass.is_laptop()
+
+
 # Allow to import the HackSoundServer from the system while using a more friendly name
 Sound = HackSoundServer
 SoundItem = HackSoundItem

--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -41,6 +41,7 @@
         "--socket=x11",
         "--system-talk-name=org.freedesktop.Accounts",
         "--system-talk-name=org.freedesktop.NetworkManager",
+        "--system-talk-name=org.freedesktop.hostname1",
         "--system-talk-name=com.endlessm.Metrics",
         "--talk-name=ca.desrt.dconf",
         "--talk-name=com.endlessm.Libanimation",


### PR DESCRIPTION
This patch uses the hostname1 DBus API to get the information of the
device chassis. So this can be used on quests to divert with something
like:

    from eosclubhouse.system import Hostname

    [...]

    if Hostname.is_laptop():
        # It's a laptop
    else:
        # It's a desktop

https://phabricator.endlessm.com/T30761