### PR TITLE
quests: De-reference Hack mode in all intro quests

### DIFF
--- a/eosclubhouse/quests/hack2/meet.py
+++ b/eosclubhouse/quests/hack2/meet.py
@@ -40,33 +40,6 @@ class Meet(Quest):
         self.highlight_nav('')
         self.wait_confirm('EXPLAIN_MAIN1')
         self.wait_confirm('EXPLAIN_MAIN2')
-        return self.step_hackmode
-
-    def step_hackmode(self):
-        # If the user played with the hack switch before the
-        # explanation, we reset to normal:
-        if not self._clubhouse_state.lights_on:
-            self._clubhouse_state.lights_on = True
-        for msgid in ['EXPLAIN_HACK1', 'EXPLAIN_HACK2']:
-            self.wait_confirm(msgid)
-        self._clubhouse_state.hack_switch_highlighted = True
-        skip_action = self.show_confirm_message('EXPLAIN_HACK3',
-                                                confirm_label="I'd prefer not to, but thanks.")
-        user_action = self.connect_clubhouse_changes(['lights-on'])
-        self.wait_for_one([skip_action, user_action])
-        self._clubhouse_state.hack_switch_highlighted = False
-        if skip_action.is_done():
-            # Automatically turn the lights off because the player
-            # wants to skip using the switcher:
-            self._clubhouse_state.lights_on = False
-        skip_action = self.show_confirm_message('EXPLAIN_HACK4', confirm_label='OK, I see.')
-        user_action = self.connect_clubhouse_changes(['lights-on'])
-        self.wait_for_one([skip_action, user_action])
-        if skip_action.is_done():
-            # Automatically turn the lights on because the player
-            # wants to skip using the switcher:
-            self._clubhouse_state.lights_on = True
-        self._clubhouse_state.hack_switch_highlighted = False
         return self.step_pathways
 
     def step_pathways(self):

--- a/eosclubhouse/quests/hack2/migration.py
+++ b/eosclubhouse/quests/hack2/migration.py
@@ -54,38 +54,10 @@ class Migration(Quest):
         self.complete = True
         for msgid in ['OLDSTUFF4', 'OLDSTUFF5']:
             self.wait_confirm(msgid)
-        return self.step_explain_new_stuff
-
-    def step_explain_new_stuff(self):
-        # explain hack mode
-        for msgid in ['NEWSTUFF', 'HACKMODE1', 'HACKMODE2']:
-            self.wait_confirm(msgid)
-        # If the user played with the hack switch before the
-        # explanation, we reset to normal:
-        if not self._clubhouse_state.lights_on:
-            self._clubhouse_state.lights_on = True
-        self._clubhouse_state.hack_switch_highlighted = True
-        skip_action = self.show_confirm_message('HACKMODE3',
-                                                confirm_label="I'd prefer not to, but thanks.")
-        user_action = self.connect_clubhouse_changes(['lights-on'])
-        self.wait_for_one([skip_action, user_action])
-        self._clubhouse_state.hack_switch_highlighted = False
-        if skip_action.is_done():
-            # Automatically turn the lights off because the player
-            # wants to skip using the switcher:
-            self._clubhouse_state.lights_on = False
-        skip_action = self.show_confirm_message('HACKMODE4', confirm_label='OK, I see.')
-        user_action = self.connect_clubhouse_changes(['lights-on'])
-        self.wait_for_one([skip_action, user_action])
-        if skip_action.is_done():
-            # Automatically turn the lights on because the player
-            # wants to skip using the switcher:
-            self._clubhouse_state.lights_on = True
-        self._clubhouse_state.hack_switch_highlighted = False
-        self.wait_confirm('HACKMODE5')
         return self.step_explain_activities
 
     def step_explain_activities(self):
+        self.wait_confirm('NEWSTUFF')
         # explain activities and how to play them
         for msgid in ['ACTIVITIES1', 'ACTIVITIES2', 'ACTIVITIES3']:
             self.wait_confirm(msgid)

--- a/eosclubhouse/quests/hack2/quickstart.py
+++ b/eosclubhouse/quests/hack2/quickstart.py
@@ -43,29 +43,6 @@ class Quickstart(Quest):
                                            ('NEGATIVE', None, False)).wait()
         if action.future.result():
             self.highlight_nav('CLUBHOUSE')
-            self.wait_confirm('HACKSWITCH1')
-            self.highlight_nav('')
-            # If the user played with the hack switch before the
-            # explanation, we reset to normal:
-            if not self._clubhouse_state.lights_on:
-                self._clubhouse_state.lights_on = True
-            self._clubhouse_state.hack_switch_highlighted = True
-            skip_action = self.show_confirm_message('HACKSWITCH2',
-                                                    confirm_label="I'd prefer not to, but thanks.")
-            user_action = self.connect_clubhouse_changes(['lights-on'])
-            self.wait_for_one([skip_action, user_action])
-            self._clubhouse_state.hack_switch_highlighted = False
-            if skip_action.is_done():
-                # Automatically turn the lights off because the player
-                # wants to skip using the switcher:
-                self._clubhouse_state.lights_on = False
-            skip_action = self.show_confirm_message('HACKSWITCH3', confirm_label='OK, I see.')
-            user_action = self.connect_clubhouse_changes(['lights-on'])
-            self.wait_for_one([skip_action, user_action])
-            if skip_action.is_done():
-                # Automatically turn the lights on because the player
-                # wants to skip using the switcher:
-                self._clubhouse_state.lights_on = True
             self.wait_confirm('ACTIVITIES')
         else:
             self.wait_confirm('DECLINE')


### PR DESCRIPTION
Removing all references to Hack Mode, as well as all code turning it on and off, from all 3 intro quests.
At some point in the future I'd like to improve/rework these quests, but for now this will remove incorrect information.

https://phabricator.endlessm.com/T30777