### PR TITLE
clubhouse: Refresh network status on every page change

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2377,6 +2377,9 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
             self._hack_news_count.hide()
 
     def set_page(self, page_name):
+        # Update the connectivity cache status
+        NetworkManager.refresh()
+
         current_page = self._stack.get_visible_child_name()
         new_page = page_name.upper()
 

--- a/eosclubhouse/network.py
+++ b/eosclubhouse/network.py
@@ -84,3 +84,12 @@ class NetworkManager:
     @classmethod
     def disconnect_connection_change(klass, handler):
         klass._get_proxy().disconnect(handler)
+
+    @classmethod
+    def refresh(klass):
+        proxy = klass._get_proxy()
+        def on_done(proxy, result, user_data):
+            # Do nothing here, this is done to make the call async so the
+            # property gets updated on the proxy cached properties.
+            pass
+        proxy.CheckConnectivity(result_handler=on_done)


### PR DESCRIPTION
This change should fix the problem with connectivity not in sync with
the real network status on EOS 3.8.

This patch adds a call to the NetworkManager DBus API to refresh the
network connectivity status every time the user changes the page in the
clubhouse.

This will update the cached value, so if you go to "Art", then turn off
the connection, go back and open "Art" again, you'll see the need
connection icon on quests.

https://phabricator.endlessm.com/T30758