### PR TITLE
libquest: Add show_highlight family method

### DIFF
--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -2270,6 +2270,69 @@ class Quest(_Quest):
 
         return async_action
 
+    def show_highlight_rect(self, x, y, width, height, text=''):
+        '''Highlight a rectangle on the desktop.
+
+        :param x: The x coordinate of the rectangle.
+        :param y: The x coordinate of the rectangle.
+        :param width: The width of the rectangle.
+        :param height: The height of the rectangle.
+        :param text: Optional text to show near the highlighted region.
+        '''
+
+        return self.show_highlight(x, y, width, height, text, function='HighlightRect')
+
+    def show_highlight_circle(self, x, y, radius, text=''):
+        '''Highlight a circle on the desktop.
+
+        :param x: The x coordinate of the circle.
+        :param y: The x coordinate of the circle.
+        :param radius: The height of the circle.
+        :param text: Optional text to show near the highlighted region.
+        '''
+
+        return self.show_highlight(x, y, radius, text, function='HighlightCircle')
+
+    def show_highlight_widget(self, name, text=''):
+        '''Highlight a widget on the desktop.
+
+        :param name: The widget name or the style class name.
+        :param text: Optional text to show near the highlighted region.
+        '''
+
+        return self.show_highlight(name, text, function='HighlightWidget')
+
+    def show_highlight_icon(self, app_id, text=''):
+        '''Highlight a desktop icon.
+
+        :param app_id: The app id.
+        :param text: Optional text to show near the highlighted region.
+        '''
+
+        return self.show_highlight(app_id, text, function='HighlightDesktopIcon')
+
+    def show_highlight_fuzzy(self, position='center', size='20%', shape='rect', text=''):
+        '''Highlight a region with a fuzzy description.
+
+        :param str size: The highlight size description. The format is the
+            same as the size parameter of the :meth:wait_for_highlight_fuzzy()
+            method.
+        :param str position: The highlight position description. The format is the
+            same as the position parameter of the :meth:wait_for_highlight_fuzzy()
+            method.
+        :param shape: The highlight shape, rect or circle.
+        '''
+
+        return self.show_highlight(position, size, shape, text, function='HighlightFuzzy')
+
+    def show_highlight(self, *args, function='HighlightRect'):
+        '''Highlight a region on the desktop.
+
+        :param function: The TourServer function to use.
+        '''
+
+        Tour._call_method(function, *args)
+
     # ** Network detection **
 
     def has_connection(self):


### PR DESCRIPTION
The current highlight method for the quests are waiters, that require
the user to click on the highlighted region for the quest to continue.

This patch adds a set of new methods to be able to show a highlighted
region without a waiter, with a similar syntax, so the quest can
continue and show dialogs on top of that.

```
    def show_highlight_rect(self, x, y, width, height, text=''):
    def show_highlight_circle(self, x, y, radius, text=''):
    def show_highlight_widget(self, name, text=''):
    def show_highlight_icon(self, app_id, text=''):
    def show_highlight_fuzzy(self, position='center', size='20%', shape='rect', text=''):
```

https://phabricator.endlessm.com/T30843