### PR TITLE
libquest: Add auto-install to wait_for_app_install

### DIFF
--- a/eosclubhouse/config.py.in
+++ b/eosclubhouse/config.py.in
@@ -15,4 +15,4 @@ NEWSFEED_CSV = @newsfeed_csv@
 DATA_DIR = @data_dir@
 RESET_SCRIPT_PATH = @reset_script_path@
 DEFAULT_EPISODE_NAME = 'hack2'
-
+DEFAULT_INSTALL_REPO = 'flathub'

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1871,11 +1871,18 @@ class Quest(_Quest):
         '''
         self._hints_given_once = set()
 
-    def wait_for_app_install(self, app=None, timeout=None):
+    def wait_for_app_install(self, app=None, confirm=True,
+                             repo=config.DEFAULT_INSTALL_REPO, timeout=None):
         '''Wait until `app` is installed.
 
         :param app: The application. If not passed, it will use :attr:`app`.
         :param timeout: If not None, the wait will timeout after this amount of seconds.
+        :param confirm: If true, the app center will be shown but the
+            installation doesn't start automatically. In other case the
+            installation will start just after the call.
+        :param repo: When confirm = True, you can provide a repository to use
+            for the installation. By default it's flathub but it could be
+            eos-apps or other flatpak repository.
         :type timeout: int or None
         :rtype: AsyncAction
 
@@ -1906,7 +1913,7 @@ class Quest(_Quest):
         # Polling the app install state
         GLib.timeout_add_seconds(1, _poll_app_install)
 
-        app.request_install()
+        app.request_install(confirm=confirm, repo=repo)
         self._run_context.wait_for_action(async_action, timeout)
         return async_action
 

--- a/eosclubhouse/software.py
+++ b/eosclubhouse/software.py
@@ -18,7 +18,7 @@
 #       Daniel Garcia <danigm@endlessos.org>
 
 
-from eosclubhouse import logger
+from eosclubhouse import config, logger
 from gi.repository import Gio, GLib
 
 
@@ -49,5 +49,19 @@ class GnomeSoftware:
 
         args = GLib.Variant('(ss)', (app_id, ''))
         variant = GLib.Variant('(sava{sv})', ['details', [args], None])
+        klass.get_proxy().call('Activate', variant,
+                               Gio.DBusCallFlags.NONE, -1, None, _on_done_callback)
+
+    @classmethod
+    def install(klass, app_id, branch='stable', repo=config.DEFAULT_INSTALL_REPO):
+        def _on_done_callback(proxy, result):
+            try:
+                proxy.call_finish(result)
+            except GLib.Error as e:
+                logger.error('Error installing app: %s', e.message)
+
+        unique_id = f'system/flatpak/{repo}/desktop/{app_id}/{branch}'
+        args = GLib.Variant('(su)', (unique_id, 1))
+        variant = GLib.Variant('(sava{sv})', ['install', [args], None])
         klass.get_proxy().call('Activate', variant,
                                Gio.DBusCallFlags.NONE, -1, None, _on_done_callback)

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -25,7 +25,7 @@ import os
 import subprocess
 import time
 
-from eosclubhouse import logger
+from eosclubhouse import config, logger
 from eosclubhouse.hackapps import HackableAppsManager
 from eosclubhouse.soundserver import HackSoundServer, HackSoundItem
 from eosclubhouse.software import GnomeSoftware
@@ -572,10 +572,13 @@ class App:
                                  'flatpak', 'info', '--show-ref', self.dbus_name])
         return result.returncode == 0
 
-    def request_install(self):
+    def request_install(self, confirm=True, repo=config.DEFAULT_INSTALL_REPO):
         '''Open the gnome-software app with the selected aplication'''
 
         GnomeSoftware.details(self.dbus_name)
+        if not confirm:
+            branch = 'eos3' if repo == 'eos-apps' else 'stable'
+            GnomeSoftware.install(self.dbus_name, branch=branch, repo=repo)
 
     def get_object_property(self, obj, prop):
         return self.get_clippy_proxy().Get('(ss)', obj, prop)


### PR DESCRIPTION
This patch adds two new optional parameters to the wait_for_app_install
method, confirm and repo.

Setting the confirm to False will launch the installation directly
without the need to click on Download on the App center.

The repo parameter should be used to select the flatpak remote
repository. By default is the eos-apps, but for other apps could be
flathub.

This will show the App center with the desired app and will start the
download inmediatly:

    self.wait_for_app_install(self.app, confirm=False, repo='eos-apps')

https://phabricator.endlessm.com/T30845