### PR TITLE
clubhouse: Handle install shell extension

### DIFF
--- a/data/clubhouse-view-main-layer.ui
+++ b/data/clubhouse-view-main-layer.ui
@@ -79,15 +79,36 @@
         <property name="can_focus">False</property>
         <property name="receives_default">False</property>
         <property name="action_name">app.install-extension</property>
-        <property name="tooltip_text" translatable="yes">Hack extension is not enabled. Click here to solve</property>
         <style>
           <class name="extension-button"/>
         </style>
         <child>
-          <object class="GtkImage">
+          <object class="GtkStack" id="_extension_button_stack">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="icon_name">dialog-warning-symbolic</property>
+            <property name="transition_type">crossfade</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">dialog-warning-symbolic</property>
+                <property name="tooltip_text" translatable="yes">Hack extension is not enabled. Click here to solve</property>
+              </object>
+              <packing>
+                <property name="name">image</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinner" id="_extension_button_spinner">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="active">True</property>
+                <property name="tooltip_text" translatable="yes">Installing hack extension…</property>
+              </object>
+              <packing>
+                <property name="name">loading</property>
+              </packing>
+            </child>
           </object>
         </child>
       </object>

--- a/data/clubhouse-view-main-layer.ui
+++ b/data/clubhouse-view-main-layer.ui
@@ -73,5 +73,28 @@
         <property name="y">329</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkButton" id="extension_button">
+        <property name="visible">False</property>
+        <property name="can_focus">False</property>
+        <property name="receives_default">False</property>
+        <property name="action_name">app.install-extension</property>
+        <property name="tooltip_text" translatable="yes">Hack extension is not enabled. Click here to solve</property>
+        <style>
+          <class name="extension-button"/>
+        </style>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">dialog-warning-symbolic</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="x">12</property>
+        <property name="y">800</property>
+      </packing>
+    </child>
   </template>
 </interface>

--- a/data/gtk-style.css
+++ b/data/gtk-style.css
@@ -804,6 +804,17 @@ ClubhouseViewMainLayer #banister {
   background-image: url("resource:///com/hack_computer/Clubhouse/images/banister.png");
   transition: background-image 200ms linear; }
 
+ClubhouseViewMainLayer .extension-button {
+  color: white;
+  text-shadow: none;
+  border: 0;
+  margin: 0;
+  padding: 3px;
+  border-radius: 3em;
+  box-shadow: 1px 1px 3px black;
+  background-color: #E01B24;
+  padding: 1em; }
+
 ClubhouseWindow.off ClubhouseViewMainLayer #banister {
   background-image: url("resource:///com/hack_computer/Clubhouse/images/banister-off.png"); }
 

--- a/data/gtk-style.sass
+++ b/data/gtk-style.sass
@@ -636,7 +636,7 @@ CharacterView
         padding: 0.3em
         background-image: none
         border-radius: 2em
-        background-color: red
+        background-color: #E01B24
         color: white
 
   &.new
@@ -972,6 +972,17 @@ ClubhouseViewMainLayer
     background-size: cover
     background-image: url($images + 'banister.png')
     transition: background-image 200ms linear
+
+  .extension-button
+    color: white
+    text-shadow: none
+    border: 0
+    margin: 0
+    padding: 3px /* this is the border offset for checked state and needs to be in pixels to avoid rounding errors */
+    border-radius: 3em
+    box-shadow: 1px 1px 3px black
+    background-color: red
+    padding: 1em
 
 ClubhouseWindow.off
   ClubhouseViewMainLayer

--- a/katamari/tools/_common.py
+++ b/katamari/tools/_common.py
@@ -206,7 +206,7 @@ def _pretty_print_source(value, indent=4, offset=16):
     lines = json.dumps(value, indent=indent).split('\n')
     # First line keeps the default offset
     head = lines[:1]
-    tail = [(' ' * offset) + l for l in lines[1:]]
+    tail = [(' ' * offset) + line for line in lines[1:]]
     return '\n'.join(head + tail)
 
 


### PR DESCRIPTION
 * Do not start quests during extension installation
 * Fallback to in app notifications if extension is not installed
 * Add alert button to install the extension if it's not installed
 * Try to install the extension after the window is shown

https://phabricator.endlessm.com/T30923