### PR TITLE
clubhouse: Detect system installed apps

### DIFF
--- a/data/tools/eos-hack-app-installed
+++ b/data/tools/eos-hack-app-installed
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+
+import sys
+from gi.repository import Gio
+
+
+try:
+    app = Gio.DesktopAppInfo.new(sys.argv[1])
+except:
+    sys.exit(1)
+
+
+sys.exit(0)

--- a/eosclubhouse/config.py.in
+++ b/eosclubhouse/config.py.in
@@ -15,5 +15,6 @@ NEWSFEED_CSV = @newsfeed_csv@
 DATA_DIR = @data_dir@
 RESET_SCRIPT_PATH = @reset_script_path@
 LAUNCH_SCRIPT_PATH = @launch_script_path@
+IS_INSTALLED_SCRIPT_PATH = @is_installed_script_path@
 DEFAULT_EPISODE_NAME = 'hack2'
 DEFAULT_INSTALL_REPO = 'flathub'

--- a/eosclubhouse/meson.build
+++ b/eosclubhouse/meson.build
@@ -28,6 +28,10 @@ conf.set_quoted(
     'launch_script_path',
     join_paths(clubhouse_data_dir, 'tools', 'eos-hack-launch')
 )
+conf.set_quoted(
+    'is_installed_script_path',
+    join_paths(clubhouse_data_dir, 'tools', 'eos-hack-app-installed')
+)
 
 configure_file(
     input: 'config.py.in',

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -24,7 +24,7 @@ import subprocess
 import time
 
 from eosclubhouse import config, logger
-from eosclubhouse.config import LAUNCH_SCRIPT_PATH
+from eosclubhouse.config import IS_INSTALLED_SCRIPT_PATH, LAUNCH_SCRIPT_PATH
 from eosclubhouse.hackapps import HackableAppsManager
 from eosclubhouse.soundserver import HackSoundServer, HackSoundItem
 from eosclubhouse.software import GnomeSoftware
@@ -681,13 +681,19 @@ class App:
 
     def is_installed(self):
         '''Check if the app is installed.
-
-        Note: This only works for apps distributed as flatpaks.
         '''
-        result = subprocess.run(['/usr/bin/flatpak-spawn', '--host',
-                                 'flatpak', 'info', '--show-ref', self.dbus_name],
-                                capture_output=True)
-        return result.returncode == 0
+
+        app_name = f'{self.dbus_name}.desktop'
+        sandbox = get_flatpak_sandbox()
+        # Remove /app
+        script = '/'.join(IS_INSTALLED_SCRIPT_PATH.split('/')[2:])
+        script_path = f'{sandbox}/{script}'
+        try:
+            subprocess.run(['/usr/bin/flatpak-spawn', '--host',
+                            script_path, app_name], check=True)
+        except Exception:
+            return False
+        return True
 
     def request_install(self, confirm=True, repo=config.DEFAULT_INSTALL_REPO):
         '''Open the gnome-software app with the selected aplication


### PR DESCRIPTION
This patch improves the App.is_installed detection method to detect also
system applications.

To check if an application is installed this method looks for the
.desktop file located in one of the following known paths:

  * First, the configs. Highest priority: the user's ~/.config
  * Next, the system configs (/etc/xdg, and so on),
  * Now the data. Highest priority: the user's ~/.local/share/applications
  * Following that, XDG_DATA_DIRS/applications, in order
  * '/var/run/host/usr/share'
  * '/var/lib/flatpak/exports/share'

This code is based on what GLib does in the `g_app_info_get_all`, but we
can't use the GLib method directly because it doesn't give us the apps
that are outside of the flatpak sandbox.

If the desktop file is not found we fallback to use the old
flatpak-spawn method.

https://phabricator.endlessm.com/T30947