### PR TITLE
katamari: update flatpak version requirement

### DIFF
--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -43,7 +43,7 @@
         "--talk-name=org.endlessos.onboarding",
         "--talk-name=org.gnome.Software",
         "--talk-name=com.endlessm.EknServices3.SearchProviderV3",
-        "--require-version=1.5.0"
+        "--require-version=1.8.2"
     ],
 
     "modules": [


### PR DESCRIPTION
This will prevent the app from being installed on older systems through
the app store as it requires the latest Flatpak version to be present on
the system.

 * EOS3.8: flatpak version 1.6.2
 * EOS3.9: flatpak version 1.8.2

https://phabricator.endlessm.com/T30736