### PR TITLE
clubhouse: Add a label to the extension button

### DIFF
--- a/data/clubhouse-view-main-layer.ui
+++ b/data/clubhouse-view-main-layer.ui
@@ -111,7 +111,8 @@
                   <object class="GtkLabel" id="_extension_button_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Hack extension is not enabled. Click here to solve</property>
+                    <property name="use-markup">True</property>
+                    <property name="label" translatable="yes">The Hack GNOME Shell Extension is not installed. &lt;b&gt;Install extension&lt;/b&gt;.</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/data/clubhouse-view-main-layer.ui
+++ b/data/clubhouse-view-main-layer.ui
@@ -88,11 +88,37 @@
             <property name="can_focus">False</property>
             <property name="transition_type">crossfade</property>
             <child>
-              <object class="GtkImage">
+              <object class="GtkBox">
+                <property name="name">no-extension-box</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">dialog-warning-symbolic</property>
-                <property name="tooltip_text" translatable="yes">Hack extension is not enabled. Click here to solve</property>
+                <property name="spacing">6</property>
+                <property name="orientation">horizontal</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">dialog-warning-symbolic</property>
+                    <property name="tooltip_text" translatable="yes">Hack extension is not enabled. Click here to solve</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="_extension_button_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Hack extension is not enabled. Click here to solve</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="name">image</property>

--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -1571,6 +1571,7 @@ class ClubhouseViewMainLayer(Gtk.Fixed):
     _hack_switch = Gtk.Template.Child()
     _hack_switch_panel = Gtk.Template.Child()
     _extension_button_stack = Gtk.Template.Child()
+    _extension_button_label = Gtk.Template.Child()
     _extension_button_spinner = Gtk.Template.Child()
     extension_button = Gtk.Template.Child()
 
@@ -1620,8 +1621,10 @@ class ClubhouseViewMainLayer(Gtk.Fixed):
         # we should stop when the page is not shown
         if installing:
             self._extension_button_spinner.start()
+            self._extension_button_label.hide()
         else:
             self._extension_button_spinner.stop()
+            self._extension_button_label.show()
 
     def _on_quest_set_highlighted_changed(self, quest_set, _param):
         if self._app_window.is_visible():


### PR DESCRIPTION
This patch adds a descriptive label to the shell extension button that
appears on the bottom left, so the user have more information without
hovering that button.

https://phabricator.endlessm.com/T30983