### PR TITLE
katamari: Add dconf access

### DIFF
--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -43,6 +43,10 @@
         "--talk-name=org.endlessos.onboarding",
         "--talk-name=org.gnome.Software",
         "--talk-name=com.endlessm.EknServices3.SearchProviderV3",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--require-version=1.8.2"
     ],
 


### PR DESCRIPTION
We need the dconf access to modify the cursor theme and size in the
System app toolbox. Without this the toolbox doesn't have any effect.

https://phabricator.endlessm.com/T31066