### PR TITLE
katamari: Remove hack-components module

### DIFF
--- a/katamari/data/config.ini.example
+++ b/katamari/data/config.ini.example
@@ -68,7 +68,6 @@ clubhouse = .
 
 # hack-sound-server = custom
 # hack-toolbox-app = custom
-# hack-components = custom
 # hack-toy-apps = custom
 # hack-game-state-service = custom
 # clubhouse = custom

--- a/katamari/tools/build-clubhouse
+++ b/katamari/tools/build-clubhouse
@@ -25,7 +25,6 @@ APP_ID = 'com.hack_computer.Clubhouse'
 MODULES = [
     'hack-sound-server',
     'hack-toolbox-app',
-    'hack-components',
     'hack-toy-apps',
     'hack-game-state-service',
     'clubhouse',


### PR DESCRIPTION
We don't need this module anymore.