### PR TITLE
clubhouse: Reload dbus on init

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2236,7 +2236,6 @@ class ClubhouseWindow(Gtk.ApplicationWindow):
 
     def __init__(self, app):
         super().__init__(application=app, title='Clubhouse')
-
         self._app = app
         self._gss = GameStateService()
         self._user = UserAccount()
@@ -3347,6 +3346,7 @@ class ClubhouseApplication(Gtk.Application):
 
     def _ensure_registry_loaded(self):
         if not self._registry_loaded:
+            Desktop.reload_dbus_config()
             libquest.Registry.load_current_episode()
             self._registry_loaded = True
 

--- a/eosclubhouse/system.py
+++ b/eosclubhouse/system.py
@@ -311,6 +311,11 @@ class Desktop:
         return True
 
     @classmethod
+    def reload_dbus_config(klass):
+        proxy = klass.get_dbus_proxy()
+        proxy.ReloadConfig()
+
+    @classmethod
     def launch_app(klass, name):
         try:
             klass.get_app_launcher_proxy().Launch('(su)', name, int(time.time()))


### PR DESCRIPTION
This is needed to ensure that the game state service and other dbus
services are exported on the first run after the installation. Some
desktops doesn't do this automatically so this call will ensure that
every dbus service is detected.

https://phabricator.endlessm.com/T31114