### PR TITLE
T31123 install msgs (Review Only)

### DIFF
--- a/data/quests_strings/blenderquest.csv
+++ b/data/quests_strings/blenderquest.csv
@@ -2,11 +2,6 @@ BLENDERQUEST_QUEST_NAME,3D Modeling - Make it Blend!,,,,
 BLENDERQUEST_FWD,❯,,,,
 BLENDERQUEST_BAK,❮,,,,
 BLENDERQUEST_QUIT,See you later!,,,,
-BLENDERQUEST_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
 BLENDERQUEST_WARN1,"So, you're interested in 3D Modeling, <b>{{user_name}}</b>?
 
 You're in luck - you can use Blender, a super-powerful 3D modeling program!

--- a/data/quests_strings/blendmonster1.csv
+++ b/data/quests_strings/blendmonster1.csv
@@ -2,11 +2,6 @@ BLENDMONSTER1_QUEST_NAME,A 3D Monster Smoothie!,,,,
 BLENDMONSTER1_QUEST_SUBTITLE,What you'll do,,,,
 BLENDMONSTER1_QUEST_DESCRIPTION,"In part 1 of this quest, start your journey towards making a full Blender scene with a spooky monster!",,,,
 BLENDMONSTER1_QUIT,See you later!,,,,
-BLENDMONSTER1_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
 BLENDMONSTER1_INFO_1,"Hey, <b>{{user_name}}</b>, welcome (or welcome back) to Blender! Don't forget that a USB mouse with 2 buttons and a scroll wheel is <b>very</b> helpful for using Blender. I <b>strongly</b> recommend it.",estelle,,,
 BLENDMONSTER1_INFO_2,The easiest way to follow along with these tutorials is to adjust your windows so that you can see both Blender and the video.,estelle,,,
 BLENDMONSTER1_INFO_3,"Here's the video - <u><span insert_hyphens=""false"" foreground=""#3584E4"">https://www.youtube.com/watch?v=7MRonzqYJgw</span></u>",estelle,,,

--- a/data/quests_strings/blendmonster2.csv
+++ b/data/quests_strings/blendmonster2.csv
@@ -2,11 +2,6 @@ BLENDMONSTER2_QUEST_NAME,Monster Smoothie - Assembling the Ingredients,,,,
 BLENDMONSTER2_QUEST_SUBTITLE,What you'll do,,,,
 BLENDMONSTER2_QUEST_DESCRIPTION,"In part 2 of this quest, it's time to dive into modeling one of the characters in your scene.",,,,
 BLENDMONSTER2_QUIT,See you later!,,,,
-BLENDMONSTER2_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
 BLENDMONSTER2_INFO_1,"Welcome back, <b>{{user_name}}</b>! I'd recommend doing the previous parts of this quest if you haven't already. If you have, or you're forging ahead, plug in your mouse and let's get modeling!",estelle,,,
 BLENDMONSTER2_INFO_2,The easiest way to follow along with these tutorials is to adjust your windows so that you can see both Blender and the video.,estelle,,,
 BLENDMONSTER2_INFO_3,"Here's the link - <u><span insert_hyphens=""false"" foreground=""#3584E4"">https://www.youtube.com/watch?v=L0AY61v6-M4</span></u>",estelle,,,

--- a/data/quests_strings/blendmonster3.csv
+++ b/data/quests_strings/blendmonster3.csv
@@ -2,11 +2,6 @@ BLENDMONSTER3_QUEST_NAME,Monster Smoothie - Chopping and Re-shaping,,,,
 BLENDMONSTER3_QUEST_SUBTITLE,What you'll do,,,,
 BLENDMONSTER3_QUEST_DESCRIPTION,"In part 3 of this quest, you'll explore new modeling techniques, and continue building the main charcter.",,,,
 BLENDMONSTER3_QUIT,See you later!,,,,
-BLENDMONSTER3_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
 BLENDMONSTER3_INFO_1,"Welcome back, <b>{{user_name}}</b>! I'd recommend doing the previous parts of this quest if you haven't already. If you have, or you're forging ahead, plug in your mouse and let's continue!",estelle,,,
 BLENDMONSTER3_INFO_2,The easiest way to follow along with these tutorials is to adjust your windows so that you can see both Blender and the video.,estelle,,,
 BLENDMONSTER3_INFO_3,"Here's your link - <u><span insert_hyphens=""false"" foreground=""#3584E4"">https://www.youtube.com/watch?v=WFzIbz2FN28</span></u>",estelle,,,

--- a/data/quests_strings/blendmonster4.csv
+++ b/data/quests_strings/blendmonster4.csv
@@ -2,11 +2,6 @@ BLENDMONSTER4_QUEST_NAME,Monster Smoothie - Texturing your Surfaces,,,,
 BLENDMONSTER4_QUEST_SUBTITLE,What you'll do,,,,
 BLENDMONSTER4_QUEST_DESCRIPTION,"In part 4 of this quest, you'll explore materials and surface textures. Give your characters a creepy look!",,,,
 BLENDMONSTER4_QUIT,See you later!,,,,
-BLENDMONSTER4_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
 BLENDMONSTER4_INFO_1,"Welcome back, <b>{{user_name}}</b>! I'd recommend doing the previous parts of this quest if you haven't already. If you have, or you're forging ahead, plug in your mouse and prepare for Materials!",estelle,,,
 BLENDMONSTER4_INFO_2,The easiest way to follow along with these tutorials is to adjust your windows so that you can see both Blender and the video.,estelle,,,
 BLENDMONSTER4_INFO_3,"Here's the link - <u><span insert_hyphens=""false"" foreground=""#3584E4"">https://www.youtube.com/watch?v=OFmKedu8r88</span></u>",estelle,,,

--- a/data/quests_strings/blendmonster5.csv
+++ b/data/quests_strings/blendmonster5.csv
@@ -2,11 +2,6 @@ BLENDMONSTER5_QUEST_NAME,Monster Smoothie - The Monster Mash!,,,,
 BLENDMONSTER5_QUEST_SUBTITLE,What you'll do,,,,
 BLENDMONSTER5_QUEST_DESCRIPTION,"At last, in part 5, you'll create your own big, freaky monster!",,,,
 BLENDMONSTER5_QUIT,See you later!,,,,
-BLENDMONSTER5_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
 BLENDMONSTER5_INFO_1,"Welcome back, <b>{{user_name}}</b>! I'd recommend doing the previous parts of this quest if you haven't already. If you have, or you're forging ahead, plug in your mouse and let's mash together a monster!",estelle,,,
 BLENDMONSTER5_INFO_2,The easiest way to follow along with these tutorials is to adjust your windows so that you can see both Blender and the video.,estelle,,,
 BLENDMONSTER5_INFO_3,"Here's the link - <u><span insert_hyphens=""false"" foreground=""#3584E4"">https://www.youtube.com/watch?v=irlEIYkeRCI</span></u>",estelle,,,

--- a/data/quests_strings/blendmonster6.csv
+++ b/data/quests_strings/blendmonster6.csv
@@ -2,11 +2,6 @@ BLENDMONSTER6_QUEST_NAME,Monster Smoothie - The Finishing Touches,,,,
 BLENDMONSTER6_QUEST_SUBTITLE,What you'll do,,,,
 BLENDMONSTER6_QUEST_DESCRIPTION,"Finally, in part 6, you'll put the finishing touches on your scene and render out a spooky final images.",,,,
 BLENDMONSTER6_QUIT,See you later!,,,,
-BLENDMONSTER6_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
 BLENDMONSTER6_INFO_1,"Welcome back, <b>{{user_name}}</b>! I'd recommend doing the previous parts of this quest if you haven't already. If you have, or you're forging ahead, plug in your mouse and get ready for rendering!",estelle,,,
 BLENDMONSTER6_INFO_2,The easiest way to follow along with these tutorials is to adjust your windows so that you can see both Blender and the video.,estelle,,,
 BLENDMONSTER6_INFO_3,"Here's the link - <u><span insert_hyphens=""false"" foreground=""#3584E4"">https://www.youtube.com/watch?v=g8683RF1COo</span></u>",estelle,,,

--- a/data/quests_strings/bootquest.csv
+++ b/data/quests_strings/bootquest.csv
@@ -2,11 +2,6 @@ BOOTQUEST_QUEST_NAME,Bootstrapping your way to faster websites,,,,
 BOOTQUEST_QUEST_SUBTITLE,What you'll do,,,,
 BOOTQUEST_QUEST_DESCRIPTION,"Learn to use Bootstrap, one of the fastest and most popular web libraries out there!",,,,
 BOOTQUEST_QUIT,See you later!,,,,
-BOOTQUEST_NOTINSTALLED,"""Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sublime Text</span></tt> isn't installed!
-
-You need to download it from the App Center because we'll be using it for this activity.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sublime Text</span></tt>, and install it.",,,,
 BOOTQUEST_1,"Hiya, <b>{{user_name}}</b>! You've been doing some great website work so far - but I'm sure you've wondered if there was a <b>really</b> fast way to build a website.",daemon,,,
 BOOTQUEST_2,"Well, there is! There's lots of code out there in these big collections called <b>libraries</b>- grab one of those, and you've got a ton of basic (and sometimes advanced!) functions and pieces already figured out for you. ",daemon,,,
 BOOTQUEST_3,"We've already hooked up all the Bootstrap bits for you - it's going to do all the heavy lifting so you can concentrate on designing the website. Let's take a look at the toolbox you'll use. If your browser doesn’t open, click on the following link: <u><span insert_hyphens=""false"" foreground=""#3584E4"">https://getbootstrap.com/docs/4.4/components/</span></u>",daemon,,,

--- a/data/quests_strings/bootquest2.csv
+++ b/data/quests_strings/bootquest2.csv
@@ -2,11 +2,6 @@ BOOTQUEST2_QUEST_NAME,Bootstrap Like a Web Developer,,,,
 BOOTQUEST2_QUEST_SUBTITLE,What you'll do,,,,
 BOOTQUEST2_QUEST_DESCRIPTION,Level up your Bootstrap game by learning how to link files for your project.,,,,
 BOOTQUEST2_QUIT,See you later!,,,,
-BOOTQUEST2_NOTINSTALLED,"""Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sublime Text</span></tt> isn't installed!
-
-You need to download it from the App Center because we'll be using it for this activity.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sublime Text</span></tt>, and install it.",daemon,,,
 BOOTQUEST2_1,"Hiya, <b>{{user_name}}</b>! Let's keep the learning juices flowing and level-up your web development skills. In this activity, we will learn how to link files for Bootstrap to work.",daemon,,,
 BOOTQUEST2_2,"We're going to pick up where we left off from the first Bootstrap quest so that we can focus on the most important parts. For this project, we'll be using Chrome (not Chromium) as our default browser. If you haven't gone through the first Bootstrap quest, we highly recommend that you work through that activity first.",daemon,,,
 BOOTQUEST2_3,"Great! Let's get started. We've added the files you're going to use in your Documents folder - let's take a look at them. The lower-left corner of the screen with the icons is called the <b>taskbar</b>. Click the yellow folder to launch the file explorer. Click the Documents link on the left panel of the window and open the <b>myproject</b> folder. The folder should contain the index.html file and three folders: <b>css</b>, <b>images</b>, and <b>js</b>. ",daemon,,,

--- a/data/quests_strings/kritacoloring.csv
+++ b/data/quests_strings/kritacoloring.csv
@@ -39,8 +39,3 @@ KRITACOLORING_35,"Doesn't it look lovely? You can do all kinds of stuff with lay
 KRITACOLORING_36,"We'll learn more about what you can add next time, and how to ""photoshop"" decorations onto your photos.",daemon2,,,
 KRITACOLORING_37,"In the meantime, you can try customizing an image of your favorite cartoon character. Just download an image from the internet, open it in Krita and use the Fill Tool. See what they look like with dyed green hair, or hot pink clothes.",daemon2,,,
 KRITACOLORING_38,See you soon!,daemon2,,,
-KRITACOLORING_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt>, and install it. ",daemon2,,,

--- a/data/quests_strings/kritaphotos.csv
+++ b/data/quests_strings/kritaphotos.csv
@@ -30,8 +30,3 @@ KRITAPHOTOS_26,"Now, let's say you wanted a brush from five minutes ago, but you
 KRITAPHOTOS_27,"This will give you a list of your most recent brushes and you can click to select the one you want. When you're done, just click on the 'Brush Presets' tab again to look for new ones.",daemon2,,,
 KRITAPHOTOS_28,"If you're feeling inspired, you might want to decorate more. Try using photos of friends and family! Create the photos you want to see in the world!",daemon2,,,
 KRITAPHOTOS_29,"Have fun, and see you next time!",daemon2,,,
-KRITAPHOTOS_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt>, and install it. ",daemon2,,,

--- a/data/quests_strings/kritaquest.csv
+++ b/data/quests_strings/kritaquest.csv
@@ -2,11 +2,6 @@ KRITAQUEST_QUEST_NAME,Digital Painting - Monet in Mirrorshades,,,,
 KRITAQUEST_FWD,❯,,,,
 KRITAQUEST_BAK,❮,,,,
 KRITAQUEST_QUIT,See you later!,,,,
-KRITAQUEST_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt>, and install it. ",daemon,,,
 KRITAQUEST_LAUNCH,"Krita's an art program for people of any skill level - it's got all the tools for amazing visuals.
 
 We've got some useful tutorials linked in here for you, give them a try!

--- a/data/quests_strings/multiplepages.csv
+++ b/data/quests_strings/multiplepages.csv
@@ -2,11 +2,6 @@ MULTIPLEPAGES_QUEST_NAME,Link It Up,,,,
 MULTIPLEPAGES_QUEST_SUBTITLE,What you'll do,,,,
 MULTIPLEPAGES_QUEST_DESCRIPTION,"In this activity, you'll upgrade your single page website to a multi-page website!",,,,
 MULTIPLEPAGES_QUIT,See you later!,,,,
-MULTIPLEPAGES_NOTINSTALLED,"""Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sublime Text</span></tt> isn't installed!
-
-You need to download it from the App Center because we'll be using it for this activity.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sublime Text</span></tt>, and install it. """,,,,
 MULTIPLEPAGES_1,"Hiya, <b>{{user_name}}</b>! You've mastered how to build your first web page, but most websites have multiple pages. For example, you might have ""About Me"", ""Projects"", ""Products"", or other pages, to give visitors more information.",daemon,,,
 MULTIPLEPAGES_2,Let's get started. We've added the files you're going to use in your <b>Documents</b> folder - let's take a look at them.,daemon,,,
 MULTIPLEPAGES_3,The <b>lower-left</b> corner of the screen with the icons is called the <b>taskbar</b>. Click the <b>yellow folder</b> icon to launch the <b>File Explorer</b>.,daemon,,,

--- a/data/quests_strings/newcursor.csv
+++ b/data/quests_strings/newcursor.csv
@@ -2,11 +2,6 @@ NEWCURSOR_QUEST_NAME,"It's not Voodoo - Creating your own mouse cursor!
 ",,,,
 NEWCURSOR_QUEST_SUBTITLE,What you'll do,,,,
 NEWCURSOR_QUEST_DESCRIPTION,Create your very own mouse pointer (cursor) that you can use across the entire operating system!,,,,
-NEWCURSOR_NOTINSTALLED,"Uh-oh! It looks like <b>GIMP</b> isn't installed!
-
-You need to download it from the App Center if you want to play this activity.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, search for <b>GIMP</b> and install it, then restart this activity.",daemon,,,
 NEWCURSOR_GREET1,"Greetings, <b>{{user_name}}</b>. I thought I'd show you a fun way to customize the operating system, today.",saniel,,,
 NEWCURSOR_GREET2,"Have you played with the System App at all yet? If not, you could to try the ""Touring the System"" activity before this one, if you want.",saniel,,,
 NEWCURSOR_GREET3,"At any rate, in the System App, you could switch your mouse cursor between various different objects - Cheese, a Unicorn, et cetera. You probably had your own idea of what would be a fun cursor, though.",saniel,,,

--- a/data/quests_strings/noquest.csv
+++ b/data/quests_strings/noquest.csv
@@ -27,42 +27,37 @@ NOQUEST_POSITIVE,👍,,,,
 NOQUEST_NEGATIVE,👎,,,,
 NOQUEST_NAV_FWD,❯,,,,
 NOQUEST_NAV_BAK,❮,,,,
-NOQUEST_NOTINSTALLED,"Uh-oh! It looks like this App isn't installed!
-
-You need to download it from the App Center if you want to play.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for the program you want to install.",daemon,,,
-NOQUEST_NOCONNECTION,"Uh-oh! It looks like you don't have an active internet connection.
-
-We need an active internet connection to display the steps and materials for this activity.
+NOQUEST_NOTINSTALLED_GENERIC,Uh-oh! It looks like the App this quest needs isn't installed! Would you like me to help you install it?,daemon,,,
+NOQUEST_AUTOINSTALL,"OK, I'll try to start the App install, this shouldn't take too long!",daemon,,,
+NOQUEST_NOCONNECTION,"Uh-oh! It looks like you don't have an active internet connection. We need an active internet connection to display the steps and materials for this activity.
 
 Come back when you've got an internet connection, and you can play this activity!",daemon,,,
 NOQUEST_QUEST_NAME,High-Clearance Memory,,,,
 NOQUEST_SUBTITLE,What could this be?,,,,
 NOQUEST_DESCRIPTION,It's a secret to everyone.,,,,
 NOQUEST_GIVE_BADGE,You've unlocked a new badge: <b>{{achievement.name}}</b>,,,,
+NOQUEST_SIDETRACK_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sidetrack</span></tt> isn't installed! We need it installed before you can play the quest.
+
+Would you like me to help you install it?",daemon,,,
+NOQUEST_SUBLIMETEXT_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sublime Text</span></tt> isn't installed! We need it installed before you can play the quest.
+
+Would you like me to help you install it?",daemon,,,
 NOQUEST_PROJLIB_NOTINSTALLED,"Uh-oh! It looks like the <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Project Library</span></tt> App isn't installed!
 You need to download it from the App Center if you want to check out this quest.
-
 Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for ""Project Library"".",daemon,,,
-NOQUEST_BLENDER_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed!
+NOQUEST_BLENDER_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt> isn't installed! We need it installed before you can play the quest.
 
-You need to download it from the App Center if you'd like to learn how to use it.
+Would you like me to help you install it?",daemon,,,
+NOQUEST_LMMS_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">LMMS</span></tt> isn't installed! We need it installed before you can play the quest.
 
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Blender</span></tt>, and install it. ",daemon,,,
-NOQUEST_LMMS_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">LMMS</span></tt> isn't installed!
+Would you like me to help you install it?",daemon,,,
+NOQUEST_GIMP_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">GIMP</span></tt> isn't installed! We need it installed before you can play the quest.
 
-You need to download it from the App Center if you'd like to learn how to use it.
+Would you like me to help you install it?",daemon,,,
+NOQUEST_KRITA_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt> isn't installed! We need it installed before you can play the quest.
 
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">LMMS</span></tt>, and install it. ",daemon,,,
-NOQUEST_GLIMPSE_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">GIMP</span></tt> isn't installed!
+Would you like me to help you install it?",daemon,,,
+NOQUEST_TURTLEBLOCKS_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">TurtleBlocks</span></tt> isn't installed! We need it installed before you can play the quest.
 
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">GIMP</span></tt>, and install it. ",daemon,,,
-NOQUEST_KRITA_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt> isn't installed!
-
-You need to download it from the App Center if you'd like to learn how to use it.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Krita</span></tt>, and install it. ",daemon,,,
+Would you like me to help you install it?",,,,
 NOQUEST_DEFAULT_ABORT,Quitting this activity - See you again soon!,daemon,,,

--- a/data/quests_strings/sidetrack1.csv
+++ b/data/quests_strings/sidetrack1.csv
@@ -1,11 +1,6 @@
 SIDETRACK1_QUEST_NAME,Sidetrack #1 - Robots and Pits,,,,
 SIDETRACK1_QUEST_SUBTITLE,What you'll do,,,,
 SIDETRACK1_QUEST_DESCRIPTION,"Explore a new game with Riley, full of robots and pits!",,,,
-SIDETRACK1_NOTINSTALLED,"Uh-oh! Looks like <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sidetrack</span></tt> isn't installed!
-
-You need to download it from the App Center to run this quest.
-
-Click the icon named <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">App Center</span></tt> on the Desktop, then search for <tt><span insert_hyphens=""false"" foreground=""#287A8C"" background=""#FFFFFF"">Sidetrack</span></tt>, and install it.",daemon,,,
 SIDETRACK1_LAUNCH_ADA,"Hi, <b>{{user_name}}</b>! I've got a new game for you to try out. It's called <b>Sidetrack</b>, and it should be sitting on your desktop. Let's check it out!",ada,,,
 SIDETRACK1_LAUNCH_ADA_HINT1,Click the <b>Sidetrack</b> icon on the desktop.,,,,quests/horse-tale
 SIDETRACK1_ASSIGNMENT_ADA,"Last summer, we decided to try something new - Instead of a book report, or an essay, all the students here at The Academy had to build a game.

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1671,17 +1671,14 @@ class Quest(_Quest):
             install_msg = 'NOQUEST_' + self.__app_common_install_name__ + '_NOTINSTALLED'
         else:
             has_install_msg = self._get_message_info('{}_NOTINSTALLED'.format(self._qs_base_id))
-            if has_install_msg:
-                install_msg = 'NOTINSTALLED'
-            else:
-                install_msg = 'NOQUEST_NOTINSTALLED_GENERIC'
+            install_msg = 'NOTINSTALLED' if has_install_msg else 'NOQUEST_NOTINSTALLED_GENERIC'
 
         action = self.show_choices_message(install_msg,
                                            ('NOQUEST_POSITIVE', None, True),
                                            ('NOQUEST_NEGATIVE', None, False)).wait()
         if action.future.result():
             self.show_message('NOQUEST_AUTOINSTALL')
-            self.wait_for_app_install(self.app, confirm=True, repo=self.__app_repository__)
+            self.wait_for_app_install(self.app, confirm=False, repo=self.__app_repository__)
             return self.step_begin
         else:
             return self.step_abort

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -1455,6 +1455,11 @@ class Quest(_Quest):
 
     '''
 
+    __app_common_install_name__ = None
+    '''If this quest's app is used by several quests, it may have a common install string
+    in the 'NOQUEST' section of the string database. See step_app_not_installed()
+    '''
+
     __app_repository__ = config.DEFAULT_INSTALL_REPO
     '''Repository of the application used by this quest, otherwise the default repo.'''
 
@@ -1653,16 +1658,29 @@ class Quest(_Quest):
         '''Step method that is executed to check if the corresponding app is installed.
 
         This method is launched before the actual quest is run. It will
-        guide the user through the installtion of the app through the
+        guide the user through the installation of the app through the
         software backend.
 
-        By default shows a message and then abort.
+        If __app_common_install_name__ is defined, it will be used to construct the install
+        question's string.
+        Failing that, if there is a quest-specific _NOTINSTALLED string available, it is used.
+        Finally, it falls back on the generic NOTINSTALLED string.
         '''
-        action = self.show_choices_message('NOQUEST_NOTINSTALLED',
+
+        if self.__app_common_install_name__ is not None:
+            install_msg = 'NOQUEST_' + self.__app_common_install_name__ + '_NOTINSTALLED'
+        else:
+            has_install_msg = self._get_message_info('{}_NOTINSTALLED'.format(self._qs_base_id))
+            if has_install_msg:
+                install_msg = 'NOTINSTALLED'
+            else:
+                install_msg = 'NOQUEST_NOTINSTALLED_GENERIC'
+
+        action = self.show_choices_message(install_msg,
                                            ('NOQUEST_POSITIVE', None, True),
                                            ('NOQUEST_NEGATIVE', None, False)).wait()
         if action.future.result():
-            self.show_message('NOQUEST_DESCRIPTION')
+            self.show_message('NOQUEST_AUTOINSTALL')
             self.wait_for_app_install(self.app, confirm=True, repo=self.__app_repository__)
             return self.step_begin
         else:

--- a/eosclubhouse/quests/hack2/blenderquest.py
+++ b/eosclubhouse/quests/hack2/blenderquest.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlenderQuest(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:hard', 'skillset:LaunchQuests', 'require:network']
     __pathway_order__ = 100
 
@@ -31,10 +32,6 @@ class BlenderQuest(Quest):
         self._info_messages = self.get_loop_messages('INFO')
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.wait_confirm('WARN1')
         self.wait_confirm('WARN2')
 

--- a/eosclubhouse/quests/hack2/blendmonster1.py
+++ b/eosclubhouse/quests/hack2/blendmonster1.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendMonster1(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:hard', 'require:network']
     __pathway_order__ = 600
 
@@ -31,10 +32,6 @@ class BlendMonster1(Quest):
         self._info_messages = self.get_loop_messages('INFO', start=1)
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendmonster2.py
+++ b/eosclubhouse/quests/hack2/blendmonster2.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendMonster2(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:hard', 'require:network']
     __pathway_order__ = 601
 
@@ -31,10 +32,6 @@ class BlendMonster2(Quest):
         self._info_messages = self.get_loop_messages('INFO', start=1)
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendmonster3.py
+++ b/eosclubhouse/quests/hack2/blendmonster3.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendMonster3(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:hard', 'require:network']
     __pathway_order__ = 602
 
@@ -31,10 +32,6 @@ class BlendMonster3(Quest):
         self._info_messages = self.get_loop_messages('INFO', start=1)
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendmonster4.py
+++ b/eosclubhouse/quests/hack2/blendmonster4.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendMonster4(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:hard', 'require:network']
     __pathway_order__ = 603
 
@@ -31,10 +32,6 @@ class BlendMonster4(Quest):
         self._info_messages = self.get_loop_messages('INFO', start=1)
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendmonster5.py
+++ b/eosclubhouse/quests/hack2/blendmonster5.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendMonster5(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:hard', 'require:network']
     __pathway_order__ = 604
 
@@ -31,10 +32,6 @@ class BlendMonster5(Quest):
         self._info_messages = self.get_loop_messages('INFO', start=1)
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendmonster6.py
+++ b/eosclubhouse/quests/hack2/blendmonster6.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendMonster6(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:hard', 'require:network']
     __pathway_order__ = 605
 
@@ -31,10 +32,6 @@ class BlendMonster6(Quest):
         self._info_messages = self.get_loop_messages('INFO', start=1)
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendperson1.py
+++ b/eosclubhouse/quests/hack2/blendperson1.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendPerson1(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:medium', 'since:1.6', 'require:network']
     __pathway_order__ = 635
 
@@ -31,12 +32,7 @@ class BlendPerson1(Quest):
         self._info_messages = self.get_loop_messages('BLENDPERSON1')
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOQUEST_BLENDER_NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
         self.wait_confirm('GREET')
-        if self.is_cancelled():
-            return self.step_abort()
         return self.step_launch
 
     def step_launch(self):

--- a/eosclubhouse/quests/hack2/blendperson2.py
+++ b/eosclubhouse/quests/hack2/blendperson2.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendPerson2(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:medium', 'since:1.6', 'require:network']
     __pathway_order__ = 636
 
@@ -31,12 +32,7 @@ class BlendPerson2(Quest):
         self._info_messages = self.get_loop_messages('BLENDPERSON2')
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOQUEST_BLENDER_NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
         self.wait_confirm('GREET')
-        if self.is_cancelled():
-            return self.step_abort()
         return self.step_launch
 
     def step_launch(self):

--- a/eosclubhouse/quests/hack2/blendwell1.py
+++ b/eosclubhouse/quests/hack2/blendwell1.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendWell1(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:medium', 'since:1.8', 'require:network']
     __pathway_order__ = 645
 
@@ -31,10 +32,6 @@ class BlendWell1(Quest):
         self._info_messages = self.get_loop_messages('BLENDWELL1')
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOQUEST_BLENDER_NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendwell2.py
+++ b/eosclubhouse/quests/hack2/blendwell2.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendWell2(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:medium', 'since:1.8', 'require:network']
     __pathway_order__ = 646
 
@@ -31,10 +32,6 @@ class BlendWell2(Quest):
         self._info_messages = self.get_loop_messages('BLENDWELL2')
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOQUEST_BLENDER_NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 

--- a/eosclubhouse/quests/hack2/blendwell3.py
+++ b/eosclubhouse/quests/hack2/blendwell3.py
@@ -24,6 +24,7 @@ from eosclubhouse.libquest import Quest
 class BlendWell3(Quest):
 
     __app_id__ = 'org.blender.Blender'
+    __app_common_install_name__ = 'BLENDER'
     __tags__ = ['pathway:art', 'difficulty:medium', 'since:1.8', 'require:network']
     __pathway_order__ = 647
 
@@ -31,10 +32,6 @@ class BlendWell3(Quest):
         self._info_messages = self.get_loop_messages('BLENDWELL3')
 
     def step_begin(self):
-        if not self.app.is_installed():
-            self.wait_confirm('NOQUEST_BLENDER_NOTINSTALLED', confirm_label='Got it!')
-            return self.step_abort
-
         self.app.launch()
         return self.step_main_loop
 


### PR DESCRIPTION
Extending the autoinstall flow to allow non-generic messages.
To do this I reworked `step_app_not_installed` - Now searches first for a 'group' install message under `__app_common_install_name__`, then a `NOTINSTALLED` string in the quest's strings, then finally falls back on the generic message.
The Blender quests have been migrated over to this new flow - let me know what you think, if this works I'll migrate all the other quests over and add them to this PR before submitting.

https://phabricator.endlessm.com/T31123