### PR TITLE
quests: Fix newcursor launch string

### DIFF
--- a/eosclubhouse/quests/hack2/newcursor.py
+++ b/eosclubhouse/quests/hack2/newcursor.py
@@ -46,7 +46,7 @@ class NewCursor(Quest):
     def step_launch(self):
         self.app.launch()
         # self.app.launch(message_id='LAUNCHGLIMPSE')
-        self.wait_confirm('LAUNCHGLIMPSE')
+        self.wait_confirm('LAUNCH')
         # self.pause(4)
         # self.wait_for_app_in_foreground(timeout=4)
         return self.step_main_loop


### PR DESCRIPTION
The LAUNCHGLIMPSE string has been renamed to LAUNCH so we need to update
in the quest:

https://github.com/endlessm/clubhouse/commit/99173acd56c8e2e76ce3cdc0ae21f19cbe208e11#diff-87365213f0e384adf5260048278471a330cc4ffab9f7fd3210f4ff1813a9b66d