### PR TITLE
metrics: configurable base url for matomo metrics

### DIFF
--- a/eosclubhouse/config.py.in
+++ b/eosclubhouse/config.py.in
@@ -21,3 +21,4 @@ DEFAULT_INSTALL_REPO = 'flathub'
 LOCALEDIR = @localedir@
 MATOMO = @matomo_host@
 MATOMO_SITE_ID = @matomo_site@
+MATOMO_BASE_URL = @matomo_base_url@

--- a/eosclubhouse/meson.build
+++ b/eosclubhouse/meson.build
@@ -39,6 +39,7 @@ conf.set_quoted(
 
 conf.set_quoted('matomo_host', get_option('matomo-host'))
 conf.set_quoted('matomo_site', get_option('matomo-site'))
+conf.set_quoted('matomo_base_url', get_option('matomo-base-url'))
 
 configure_file(
     input: 'config.py.in',

--- a/eosclubhouse/metrics.py
+++ b/eosclubhouse/metrics.py
@@ -166,7 +166,7 @@ def _get_matomo_data():
     return data
 
 
-def _build_fake_url(data, base='https://hack-computer.com/'):
+def _build_fake_url(data, base=config.MATOMO_BASE_URL):
     if isinstance(data, tuple) or isinstance(data, list):
         values = [_build_fake_url(v, base='') for v in data]
         return base + '/'.join(values)
@@ -205,7 +205,7 @@ def _build_custom_vars(extra={}):
 
 def record(event, payload, custom={}):
 
-    base = f'https://hack-computer.com/{event}/'
+    base = f'{config.MATOMO_BASE_URL}/{event}/'
     data = {
         **_get_matomo_data(),
         'action_name': event,
@@ -216,7 +216,7 @@ def record(event, payload, custom={}):
 
 
 def record_start(event, key, payload, custom={}):
-    base = f'https://hack-computer.com/{event}/{key}/'
+    base = f'{config.MATOMO_BASE_URL}/{event}/{key}/'
     data = {
         **_get_matomo_data(),
         'action_name': f'{event}_START',
@@ -227,7 +227,7 @@ def record_start(event, key, payload, custom={}):
 
 
 def record_stop(event, key, payload, custom={}):
-    base = f'https://hack-computer.com/{event}/{key}/'
+    base = f'{config.MATOMO_BASE_URL}/{event}/{key}/'
     data = {
         **_get_matomo_data(),
         'action_name': f'{event}_STOP',

--- a/katamari/com.hack_computer.Clubhouse.json.in
+++ b/katamari/com.hack_computer.Clubhouse.json.in
@@ -209,6 +209,7 @@
                 "-Dsession-bus-services-dir=/app/share/dbus-1/services",
                 "-Dmatomo-host=${CLUBHOUSE_MATOMO_HOST}",
                 "-Dmatomo-site=${CLUBHOUSE_MATOMO_SITE}",
+                "-Dmatomo-base-url=${CLUBHOUSE_MATOMO_BASE_URL}",
                 "-Drun-lint=${CLUBHOUSE_RUN_LINT}"
             ],
             "run-tests": ${CLUBHOUSE_RUN_TESTS},

--- a/katamari/data/config.ini.example
+++ b/katamari/data/config.ini.example
@@ -78,8 +78,9 @@ clubhouse = .
 
 # run_lint = yes
 # run_tests = yes
-# matomo_host = http://matomo.test.endlessos.org
-# matomo_site = 1
+# matomo_host = https://endlessos.matomo.cloud
+# matomo_site = 2
+# matomo_base_url = https://www.endlessos.org
 
 [Advanced]
 

--- a/katamari/data/config.ini.flathub
+++ b/katamari/data/config.ini.flathub
@@ -80,6 +80,9 @@ clubhouse = .
 run_lint = no
 run_tests = yes
 build_args = []
+matomo_host = https://endlessos.matomo.cloud
+matomo_site = 1
+matomo_base_url = https://www.endlessos.org
 
 [Advanced]
 

--- a/katamari/tools/build-clubhouse
+++ b/katamari/tools/build-clubhouse
@@ -41,8 +41,9 @@ DEFAULTS = {
     'clubhouse': {
         'run_lint': True,
         'run_tests': True,
-        'matomo_host': 'http://matomo.test.endlessos.org',
-        'matomo_site': '1',
+        'matomo_host': 'https://endlessos.matomo.cloud',
+        'matomo_site': '2',
+        'matomo_base_url': 'https://www.endlessos.org',
         'build_args': [ '--share=network' ],
     },
 }

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -20,3 +20,9 @@ option('matomo-site',
        type: 'string',
        value: '1'
 )
+
+option('matomo-base-url',
+       description: 'The default url to use for matomo urls',
+       type: 'string',
+       value: 'https://www.endlessos.org'
+)


### PR DESCRIPTION
This patch makes configurable the base url for matomo metrics paths and
also sets the default to https://www.endlessos.org instead of
hack-computer.

https://phabricator.endlessm.com/T31117