### PR TITLE
libquest: Fix alternative location quest loading

### DIFF
--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -3626,6 +3626,9 @@ class ClubhouseApplication(Gtk.Application):
                 return 1
         else:
             episode_name = libquest.Registry.get_loaded_episode_name()
+            # episode_name can be None if it's not loaded yet, so we fallback
+            # to default
+            episode_name = episode_name or config.DEFAULT_EPISODE_NAME
 
         libquest.Registry.set_current_episode(episode_name, force=True)
         libquest.Registry.load_current_episode()

--- a/eosclubhouse/libquest.py
+++ b/eosclubhouse/libquest.py
@@ -228,6 +228,11 @@ class Registry(GObject.GObject):
 
             class_._loaded_episode = episode_name
 
+            # loading custom quests on HOME folder. This should be done before
+            # the episode loading because in other case the quest is not added
+            # to the pathway
+            class_.load(get_alternative_quests_dir())
+
             episode_folder = class_._get_episode_folder(episode_name)
 
             module = class_._get_episode_module(episode_folder)
@@ -246,8 +251,6 @@ class Registry(GObject.GObject):
 
             loaded_episodes[episode_name] = class_._loaded_episode
             episode_name = class_.get_current_episode()['name']
-
-        class_.load(get_alternative_quests_dir())
 
     @classmethod
     def get_loaded_episode_name(class_):
@@ -349,8 +352,13 @@ class Registry(GObject.GObject):
         for subclass in Quest.__subclasses__():
             # Avoid matching subclasses with the same name but in different episodes
             episode = subclass.__module__.split('.', 1)[0]
-            if episode != current_episode:
+
+            # custom quest in the HOME folder doesn't have a real episode name
+            # and the module is quests
+            is_alternative_quests = 'quests' == episode
+            if not is_alternative_quests and episode != current_episode:
                 continue
+
             yield subclass
 
     @classmethod


### PR DESCRIPTION
With the hack2 default episode and QuestSets, the alternative location
quests were loaded but were not placed correctly in the Registry.

The alternative location quests are loaded as "quests.QuestClassName",
so the "episode" calculated for these quests is always "quests".

This patch loads this kind of quests on any episode.

We also need to call the `load` for this alternative location before the
episode load, because the QuestSets are created on the "hack2" quest and
quests are added to the QuestSets during the creation, so the custom
quests should be loaded before.

This patch also take care of the --set-quest=QuestClassName parameter to
launch the quest correctly without the need of an episode_name.

https://phabricator.endlessm.com/T31193