### PR TITLE
achievemets: Only show notification if user-initiated

### DIFF
--- a/eosclubhouse/achievements.py
+++ b/eosclubhouse/achievements.py
@@ -36,7 +36,7 @@ class _AchievementsManager(GObject.Object):
 
     __gsignals__ = {
         'achievement-achieved': (
-            GObject.SignalFlags.RUN_FIRST, None, (object, )
+            GObject.SignalFlags.RUN_FIRST, None, (object, bool)
         ),
     }
 
@@ -115,7 +115,7 @@ class _AchievementsManager(GObject.Object):
                 continue
 
             if not self.achieved(achievement, previous_points) and self.achieved(achievement):
-                self.emit('achievement-achieved', achievement)
+                self.emit('achievement-achieved', achievement, record_points)
                 if record_points:
                     self._record_achievement(skillset, achievement)
 

--- a/eosclubhouse/clubhouse.py
+++ b/eosclubhouse/clubhouse.py
@@ -2026,8 +2026,7 @@ class AchievementsView(Gtk.Box):
         self._achievement_summary_view.show_all()
 
         self._populate()
-        self._manager.connect('achievement-achieved',
-                              lambda _manager, achievement: self._give_achievement(achievement))
+        self._manager.connect('achievement-achieved', self._give_achievement)
 
         self._event_box.connect('motion-notify-event', self._motion_notify_event_cb)
         self._event_box.connect('leave-notify-event', self._leave_notify_event_cb)
@@ -2066,11 +2065,13 @@ class AchievementsView(Gtk.Box):
         for achievement in self._manager.get_achievements_achieved():
             self._add_achievement(achievement)
 
-    def _give_achievement(self, achievement):
-        if self._app.use_inapp_notifications:
-            self._inapp_popup_achievement_badge(achievement)
-        else:
-            self._shell_popup_achievement_badge(achievement)
+    def _give_achievement(self, _manager, achievement, user_initiated=False):
+        if user_initiated:
+            if self._app.use_inapp_notifications:
+                self._inapp_popup_achievement_badge(achievement)
+            else:
+                self._shell_popup_achievement_badge(achievement)
+
         self._add_achievement(achievement)
 
     def _shell_popup_achievement_badge(self, achievement):


### PR DESCRIPTION
The achievement-achieved signal is emited for every achievement on
clubhouse startup because we don't record the achivements, we calculate
on runtime with the current state.

We only want to show the notification when this signal is emited after a
quest completion. That's done already for metrics so we should do the
same for the notifications.

This patch just adds a new boolean parameter to the achievement-achieved
signal that's true when the event was user initiated. This new parameter
is used to show the notification dialog.

https://phabricator.endlessm.com/T31194