### PR TITLE
Add Education category to metainfo

### DIFF
--- a/data/com.hack_computer.Clubhouse.metainfo.xml
+++ b/data/com.hack_computer.Clubhouse.metainfo.xml
@@ -12,6 +12,7 @@
 
   <categories>
     <category>LearnToCode</category>
+    <category>Education</category>
   </categories>
 
   <releases>


### PR DESCRIPTION
The `Education` category is what’s defined in the [freedesktop menu specification](https://specifications.freedesktop.org/menu-spec/latest/apas02.html); the `LearnToCode` category was custom and not supported outside Endless’ fork of gnome-software. The changes in gnome-software to support it have now been dropped.

https://phabricator.endlessm.com/T33044