### PR TITLE
Add correct OARS data to Clubhouse

### DIFF
--- a/data/com.hack_computer.Clubhouse.metainfo.xml
+++ b/data/com.hack_computer.Clubhouse.metainfo.xml
@@ -75,5 +75,8 @@
   <launchable type="desktop-id">com.hack_computer.Clubhouse.desktop</launchable>
   <developer_name>The Hack Team</developer_name>
 
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1">
+    <content_attribute id="language-humor">mild</content_attribute>
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
 </component>


### PR DESCRIPTION
Quoting the OARS generator
<https://hughsie.github.io/oars/generate.html>:

* Humor is “defined as the quality of being amusing.  For example, this
  would include in-app jokes.” Mild means “slapstick humor”, and causes
  GNOME Software to assign a minimum age of 3.
* Information Sharing is “Defined as sharing information with a legal
  entity typically used for advertising or for sending back diagnostic
  data.  For example, this would include sending your purchasing history
  to Amazon.” Moderate means “Sharing diagnostic data not identifiable
  to the user, e.g. profiling data” and is described by GNOME Software
  as “Sharing diagnostic data that does not let others identify the
  user”. This rating causes Software to assign a minimum age of 13.

https://phabricator.endlessm.com/T26919
